### PR TITLE
Index-based services

### DIFF
--- a/invenio_users_resources/ext.py
+++ b/invenio_users_resources/ext.py
@@ -40,7 +40,9 @@ class InvenioUsersResources(object):
     def init_services(self, app):
         """Initialize the services for users and user groups."""
         self.users_service = UsersService(config=UsersServiceConfig)
-        self.user_groups_service = UserGroupsService(config=UserGroupsServiceConfig)
+        self.user_groups_service = UserGroupsService(
+            config=UserGroupsServiceConfig
+        )
 
     def init_resources(self, app):
         """Initialize the resources for users and user groups."""

--- a/invenio_users_resources/records/__init__.py
+++ b/invenio_users_resources/records/__init__.py
@@ -1,0 +1,16 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Data-layer definitions for user and group management in Invenio."""
+
+from .api import UserAggregate, UserGroupAggregate
+
+__all__ = (
+    "UserAggregate",
+    "UserGroupAggregate",
+)

--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -9,7 +9,6 @@
 """API classes for user and group management in Invenio."""
 
 
-from invenio_accounts.models import Role, User
 from invenio_accounts.proxies import current_datastore
 from invenio_db import db
 from invenio_records.dumpers import ElasticsearchDumper
@@ -162,7 +161,7 @@ class UserGroupAggregate(Record):
     """The model class for the user group aggregate."""
 
     # NOTE: the "uuid" isn't a UUID but contains the same value as the "id"
-    #       field, which is currently an integer for User objects!
+    #       field, which is currently an integer for Role objects!
     dumper = ElasticsearchDumper(
         extensions=[], model_fields={"id": ("uuid", int)}
     )
@@ -208,14 +207,14 @@ class UserGroupAggregate(Record):
         """Update the aggregate data on commit."""
         # TODO this does not allow us to set properties via the aggregate?
         #      because everything's taken from the Role object...
-        data = parse_role_data(self.user)
+        data = parse_role_data(self.role)
         self.update(data)
         self.model.update(data)
         return self
 
     @classmethod
     def from_role(cls, role):
-        """Create the user aggregate from the given role."""
+        """Create the user group aggregate from the given role."""
         # TODO
         data = parse_role_data(role)
 

--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -1,0 +1,235 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""API classes for user and group management in Invenio."""
+
+
+from invenio_accounts.models import Role, User
+from invenio_accounts.proxies import current_datastore
+from invenio_db import db
+from invenio_records.dumpers import ElasticsearchDumper
+from invenio_records.systemfields import ConstantField, DictField, ModelField
+from invenio_records_resources.records.api import Record
+from invenio_records_resources.records.systemfields import IndexField
+
+from .models import UserAggregateModel, UserGroupAggregateModel
+
+
+def parse_user_data(user):
+    """Parse the user's information into a dictionary."""
+    data = {
+        "id": user.id,
+        "email": user.email,
+        "username": None,
+        "full_name": None,
+    }
+
+    if user.profile is not None:
+        data["full_name"] = user.profile.full_name
+        data["username"] = user.profile.username
+        # TODO populate more when we have extensible user profiles
+
+    return data
+
+
+def parse_role_data(role):
+    """Parse the role's information into a dictionary."""
+    data = {"id": role.id, "name": role.name, "description": role.description}
+    return data
+
+
+class UserAggregate(Record):
+    """An aggregate of information about a user."""
+
+    model_cls = UserAggregateModel
+    """The model class for the request."""
+
+    # NOTE: the "uuid" isn't a UUID but contains the same value as the "id"
+    #       field, which is currently an integer for User objects!
+    dumper = ElasticsearchDumper(
+        extensions=[], model_fields={"id": ("uuid", int)}
+    )
+    """Elasticsearch dumper with configured extensions."""
+
+    metadata = None
+    """Disabled metadata field from the base class."""
+
+    schema = ConstantField("$schema", "local://users/user-v1.0.0.json")
+    """The JSON Schema to use for validation."""
+
+    index = IndexField("users-user-v1.0.0", search_alias="users")
+    """The Elasticsearch index to use."""
+
+    # TODO
+    id = ModelField("id")
+    """The data-layer id."""
+
+    email = DictField("email")
+    """The user's email address."""
+
+    username = DictField("username")
+    """The user's username."""
+
+    full_name = DictField("full_name")
+    """The user's full name."""
+
+    _user = None
+    """The cached User entity."""
+
+    @property
+    def user(self):
+        """Cache for the associated user object."""
+        user = self._user
+        if user is None:
+            id_, email = self.id, self.email
+            user = current_datastore.get_user(id_ or email)
+
+            self._user = user
+
+        return user
+
+    @classmethod
+    def create(
+        cls, data, id_=None, validator=None, format_checker=None, **kwargs
+    ):
+        # NOTE: we don't use an actual database table, and as such can't
+        #       use db.session.add(record.model)
+        # TODO: should we do some JSON Schema validation here?
+        #       or do we rely on marshmallow?
+        with db.session.begin_nested():
+            email = data["email"]
+            active = data.pop("active", True)
+
+            full_name = data.pop("full_name", None)
+            username = data.pop("username", None)
+
+            # TODO populate user profile
+            if full_name and username:
+                pass
+
+            user = current_datastore.create_user(email=email, active=active)
+            user_aggregate = cls.from_user(user)
+
+            return user_aggregate
+
+    def _validate(self, *args, **kwargs):
+        """Skip the validation."""
+        # TODO does a JSONSchema even make sense? we don't actually store
+        #      anything, we just collect data from all over the place
+        pass
+
+    def commit(self):
+        """Update the aggregate data on commit."""
+        # TODO this does not allow us to set properties via the UserAggregate?
+        #      because everything's taken from the User object...
+        data = parse_user_data(self.user)
+        self.update(data)
+        self.model.update(data)
+        return self
+
+    @classmethod
+    def from_user(cls, user):
+        """Create the user aggregate from the given user."""
+        # TODO
+        data = parse_user_data(user)
+
+        model = cls.model_cls(data)
+        user_agg = cls(data, model=model)
+        user_agg._user = user
+        return user_agg
+
+    @classmethod
+    def get_record(cls, id_):
+        """Get the user via the specified ID."""
+        # TODO the the datastore.get_user() method will resolve both
+        #      ID as well as email, which we do not necessarily want
+        user = current_datastore.get_user(id_)
+        if user is None:
+            return None
+
+        return cls.from_user(user)
+
+
+class UserGroupAggregate(Record):
+    """An aggregate of information about a user group/role."""
+
+    model_cls = UserGroupAggregateModel
+    """The model class for the user group aggregate."""
+
+    # NOTE: the "uuid" isn't a UUID but contains the same value as the "id"
+    #       field, which is currently an integer for User objects!
+    dumper = ElasticsearchDumper(
+        extensions=[], model_fields={"id": ("uuid", int)}
+    )
+
+    metadata = None
+    """Disabled metadata field from the base class."""
+
+    schema = ConstantField("$schema", "local://users/group-v1.0.0.json")
+    """The JSON Schema to use for validation."""
+
+    index = IndexField("user_groups-group-v1.0.0", search_alias="user_groups")
+    """The Elasticsearch index to use."""
+
+    # TODO
+    id = ModelField("id")
+    """The data-layer id."""
+
+    name = DictField("name")
+    """The group's name."""
+
+    description = DictField("description")
+    """The group's description."""
+
+    _role = None
+    """The cached Role entity."""
+
+    @property
+    def role(self):
+        """Cache for the associated role object."""
+        role = self._role
+        if role is None:
+            if self.id is not None:
+                role = current_datastore.role_model.query.get(self.id)
+
+            if role is None and self.name is not None:
+                role = current_datastore.find_role(self.name)
+
+            self._role = role
+
+        return role
+
+    def commit(self):
+        """Update the aggregate data on commit."""
+        # TODO this does not allow us to set properties via the aggregate?
+        #      because everything's taken from the Role object...
+        data = parse_role_data(self.user)
+        self.update(data)
+        self.model.update(data)
+        return self
+
+    @classmethod
+    def from_role(cls, role):
+        """Create the user aggregate from the given role."""
+        # TODO
+        data = parse_role_data(role)
+
+        model = cls.model_cls(data)
+        role_agg = cls(data, model=model)
+        role_agg._role = role
+        return role_agg
+
+    @classmethod
+    def get_record(cls, id_):
+        """Get the user group via the specified ID."""
+        # TODO how do we want to resolve the roles? via ID or name?
+        role = current_datastore.role_model.query.get(id_)
+        if role is None:
+            return None
+
+        return cls.from_role(role)

--- a/invenio_users_resources/records/jsonschemas/__init__.py
+++ b/invenio_users_resources/records/jsonschemas/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""JSONSchema directory."""

--- a/invenio_users_resources/records/jsonschemas/users/group-v1.0.0.json
+++ b/invenio_users_resources/records/jsonschemas/users/group-v1.0.0.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "local://users/group-v1.0.0.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "$ref": "local://definitions-v1.0.0.json#/$schema"
+    },
+    "id": {
+      "$ref": "local://definitions-v1.0.0.json#/identifier"
+    },
+    "name": {
+      "$ref": "string"
+    }
+  }
+}

--- a/invenio_users_resources/records/jsonschemas/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/jsonschemas/users/user-v1.0.0.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "local://users/user-v1.0.0.json",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "$ref": "local://definitions-v1.0.0.json#/$schema"
+    },
+    "id": {
+      "$ref": "local://definitions-v1.0.0.json#/identifier"
+    },
+    "email": {
+      "type": "string"
+    },
+    "username": {
+      "type": "string"
+    },
+    "full_name": {
+      "type": "string"
+    }
+  }
+}

--- a/invenio_users_resources/records/mappings/__init__.py
+++ b/invenio_users_resources/records/mappings/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Mappings directory."""

--- a/invenio_users_resources/records/mappings/v6/__init__.py
+++ b/invenio_users_resources/records/mappings/v6/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Elasticsearch version 6 mappings."""

--- a/invenio_users_resources/records/mappings/v6/user_groups/group-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/v6/user_groups/group-v1.0.0.json
@@ -1,0 +1,33 @@
+{
+  "mappings": {
+    "_doc": {
+      "dynamic": "strict",
+      "properties": {
+        "$schema": {
+          "type": "keyword"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "version_id": {
+          "type": "keyword"
+        },
+        "uuid": {
+          "type": "keyword"
+        },
+        "created": {
+          "type": "date"
+        },
+        "updated": {
+          "type": "date"
+        },
+        "name": {
+          "type": "text"
+        },
+        "description": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}

--- a/invenio_users_resources/records/mappings/v6/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/v6/users/user-v1.0.0.json
@@ -1,0 +1,48 @@
+{
+  "mappings": {
+    "_doc": {
+      "dynamic": "strict",
+      "dynamic_templates": [
+          {
+            "profile": {
+              "path_match": "profile.*",
+              "mapping": {
+                "type": "keyword"
+              }
+            }
+          }
+      ],
+      "properties": {
+        "$schema": {
+          "type": "keyword",
+          "index": "false"
+        },
+        "id": {
+          "type": "keyword"
+        },
+        "version_id": {
+          "type": "integer",
+          "index": "false"
+        },
+        "uuid": {
+          "type": "keyword"
+        },
+        "created": {
+          "type": "date"
+        },
+        "updated": {
+          "type": "date"
+        },
+        "email": {
+          "type": "keyword"
+        },
+        "username": {
+          "type": "keyword"
+        },
+        "full_name": {
+          "type": "text"
+        }
+      }
+    }
+  }
+}

--- a/invenio_users_resources/records/mappings/v7/__init__.py
+++ b/invenio_users_resources/records/mappings/v7/__init__.py
@@ -1,0 +1,9 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Elasticsearch version 7 mappings."""

--- a/invenio_users_resources/records/mappings/v7/user_groups/group-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/v7/user_groups/group-v1.0.0.json
@@ -1,0 +1,31 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "properties": {
+      "$schema": {
+        "type": "keyword"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "keyword"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "name": {
+        "type": "text"
+      },
+      "description": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/invenio_users_resources/records/mappings/v7/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/v7/users/user-v1.0.0.json
@@ -1,0 +1,46 @@
+{
+  "mappings": {
+    "dynamic": "strict",
+    "dynamic_templates": [
+        {
+          "profile": {
+            "path_match": "profile.*",
+            "mapping": {
+              "type": "keyword"
+            }
+          }
+        }
+    ],
+    "properties": {
+      "$schema": {
+        "type": "keyword",
+        "index": "false"
+      },
+      "id": {
+        "type": "keyword"
+      },
+      "version_id": {
+        "type": "integer",
+        "index": "false"
+      },
+      "uuid": {
+        "type": "keyword"
+      },
+      "created": {
+        "type": "date"
+      },
+      "updated": {
+        "type": "date"
+      },
+      "email": {
+        "type": "keyword"
+      },
+      "username": {
+        "type": "keyword"
+      },
+      "full_name": {
+        "type": "text"
+      }
+    }
+  }
+}

--- a/invenio_users_resources/records/models.py
+++ b/invenio_users_resources/records/models.py
@@ -1,0 +1,74 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Base model classes for user and group management in Invenio."""
+
+import uuid
+
+from invenio_accounts.models import Role, User
+from invenio_db import db
+from invenio_records.models import RecordMetadataBase
+from sqlalchemy.types import Integer
+from sqlalchemy_utils import UUIDType
+
+
+class MockModel(dict):
+    """Model class that does not correspondond to a database table.
+
+    Since we already have all information about the required entities
+    stored in the database and just want to provide a central API to
+    manage these entities as one, we do not want to store any of the
+    information in the database again.
+    Instead, we provide a mock model that provides the model interface
+    that's expected by API classes as far as necessary.
+    """
+
+    def __init__(self, data=None, **kwargs):
+        """Constructor."""
+        data.update(kwargs)
+        super().__init__(data)
+
+    @property
+    def id(self):
+        return self.data["id"]
+
+    @property
+    def created(self):
+        # TODO utcnow?
+        return None
+
+    @property
+    def updated(self):
+        # TODO same as above
+        return None
+
+    @property
+    def data(self):
+        return dict(self)
+
+    @property
+    def json(self):
+        return dict(self)
+
+    @property
+    def version_id(self):
+        # TODO
+        return 1
+
+    @property
+    def is_deleted(self):
+        # TODO
+        return False
+
+
+class UserAggregateModel(MockModel):
+    """Mock model for glueing together various parts of user info."""
+
+
+class UserGroupAggregateModel(MockModel):
+    """Mock model for glueing together various parts of user group info."""

--- a/invenio_users_resources/records/models.py
+++ b/invenio_users_resources/records/models.py
@@ -8,14 +8,6 @@
 
 """Base model classes for user and group management in Invenio."""
 
-import uuid
-
-from invenio_accounts.models import Role, User
-from invenio_db import db
-from invenio_records.models import RecordMetadataBase
-from sqlalchemy.types import Integer
-from sqlalchemy_utils import UUIDType
-
 
 class MockModel(dict):
     """Model class that does not correspondond to a database table.

--- a/invenio_users_resources/services/groups/config.py
+++ b/invenio_users_resources/services/groups/config.py
@@ -11,8 +11,10 @@
 from invenio_records_resources.services import RecordServiceConfig, \
     SearchOptions, pagination_links
 
+from ...records.api import UserGroupAggregate
 from ..common import Link
 from ..permissions import UsersPermissionPolicy
+from ..schemas import UserGroupSchema
 from .results import UserGroupItem, UserGroupList
 
 
@@ -33,8 +35,8 @@ class UserGroupsServiceConfig(RecordServiceConfig):
     search = UserGroupSearchOptions
 
     # specific configuration
-    record_cls = None
-    schema = None
+    record_cls = UserGroupAggregate
+    schema = UserGroupSchema
     index_dumper = None
 
     # links configuration

--- a/invenio_users_resources/services/groups/service.py
+++ b/invenio_users_resources/services/groups/service.py
@@ -9,8 +9,7 @@
 """User groups service."""
 
 from invenio_accounts.models import Role
-from invenio_accounts.proxies import current_datastore
-from invenio_records_resources.services import LinksTemplate, RecordService
+from invenio_records_resources.services import RecordService
 
 from ...records.api import UserGroupAggregate
 

--- a/invenio_users_resources/services/permissions.py
+++ b/invenio_users_resources/services/permissions.py
@@ -9,14 +9,14 @@
 """Users and user groups permissions."""
 
 from invenio_records_permissions import BasePermissionPolicy
-from invenio_records_permissions.generators import AnyUser, Disable
+from invenio_records_permissions.generators import AnyUser, SystemProcess
 
 
 class UsersPermissionPolicy(BasePermissionPolicy):
     """Permission policy for users and user groups."""
 
-    can_create = [Disable()]
-    can_read = [AnyUser()]
-    can_search = [AnyUser()]
-    can_update = [Disable()]
-    can_delete = [Disable()]
+    can_create = [SystemProcess()]
+    can_read = [AnyUser(), SystemProcess()]
+    can_search = [AnyUser(), SystemProcess()]
+    can_update = [SystemProcess()]
+    can_delete = [SystemProcess()]

--- a/invenio_users_resources/services/schemas.py
+++ b/invenio_users_resources/services/schemas.py
@@ -9,9 +9,7 @@
 
 from flask_babelex import lazy_gettext as _
 from invenio_records_resources.services.records.schema import BaseRecordSchema
-from marshmallow import Schema, ValidationError, fields, missing, pre_load, \
-    validates
-from marshmallow_utils.fields import Links
+from marshmallow import Schema, ValidationError, fields
 
 
 def validate_visibility(value):

--- a/invenio_users_resources/services/users/config.py
+++ b/invenio_users_resources/services/users/config.py
@@ -11,8 +11,10 @@
 from invenio_records_resources.services import RecordServiceConfig, \
     SearchOptions, pagination_links
 
+from ...records.api import UserAggregate
 from ..common import Link
 from ..permissions import UsersPermissionPolicy
+from ..schemas import UserSchema
 from .results import UserItem, UserList
 
 
@@ -33,8 +35,8 @@ class UsersServiceConfig(RecordServiceConfig):
     search = UserSearchOptions
 
     # specific configuration
-    record_cls = None
-    schema = None
+    record_cls = UserAggregate
+    schema = UserSchema
     index_dumper = None
 
     # links configuration

--- a/invenio_users_resources/services/users/service.py
+++ b/invenio_users_resources/services/users/service.py
@@ -9,9 +9,8 @@
 """Users service."""
 
 from invenio_accounts.models import User
-from invenio_records_resources.services import LinksTemplate, RecordService
-from invenio_records_resources.services.uow import RecordCommitOp, \
-    RecordDeleteOp, unit_of_work
+from invenio_records_resources.services import RecordService
+from invenio_records_resources.services.uow import RecordCommitOp, unit_of_work
 
 from ...records.api import UserAggregate
 

--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,13 @@ setup(
             "invenio_users = invenio_users_resources.views:create_users_resources_bp",  # noqa
             "invenio_user_groups = invenio_users_resources.views:create_user_groups_resources_bp",  # noqa
         ],
+        "invenio_jsonschemas.schemas": [
+            "jsonschemas = invenio_users_resources.records.jsonschemas",
+        ],
+        "invenio_search.mappings": [
+            "users = invenio_users_resources.records.mappings",
+            "user_groups = invenio_users_resources.records.mappings",
+        ],
         "invenio_i18n.translations": [
             "messages = invenio_users_resources",
         ],


### PR DESCRIPTION
Make the services operate on Elasticsearch indices rather than DB queries.
This requires API classes for UserAggregations, along with mock models (which don't save anything to the database, because this would effectively duplicate information).
Even though they're not saved in DB, these entities still need to be indexed in ES (which needs mappings).

For now, the focus is on "read" operations, as there's other mechanisms to create users and roles.
I've still added a rudimentary "create" operation for users, mainly for testing purposes (a single function that creates and indexes users/aggregations).

This PR primarily lays the foundation for having the services work with Elasticsearch indices (and schemas, etc.) rather than via direct DB look-ups.
The details of the schemas, APIs (especially where and how to create and update users/groups), etc. should be addressed in follow-up PRs.