### PR TITLE
users: use user model version_id and register session event hooks

### DIFF
--- a/invenio_users_resources/ext.py
+++ b/invenio_users_resources/ext.py
@@ -9,11 +9,19 @@
 
 """Invenio module providing management APIs for users and roles/groups."""
 
+from collections import defaultdict
+
+from invenio_accounts.models import Role, User
+from invenio_db import db
+from invenio_userprofiles.models import UserProfile
+from sqlalchemy import event
+
 from . import config
 from .resources import GroupsResource, GroupsResourceConfig, UsersResource, \
     UsersResourceConfig
 from .services import GroupsService, GroupsServiceConfig, UsersService, \
     UsersServiceConfig
+from .utils import reindex_group, reindex_user, unindex_group, unindex_user
 
 
 class InvenioUsersResources(object):
@@ -29,6 +37,7 @@ class InvenioUsersResources(object):
         self.init_config(app)
         self.init_services(app)
         self.init_resources(app)
+        self.init_db_hooks(app)
         app.extensions["invenio-users-resources"] = self
 
     def init_config(self, app):
@@ -52,3 +61,93 @@ class InvenioUsersResources(object):
             service=self.groups_service,
             config=GroupsResourceConfig,
         )
+
+    def init_db_hooks(self, app):
+        """Initialize the database hooks for reindexing updated users/roles."""
+        # make sure that the hooks are only registered once per DB connection
+        # and not once per app
+        if hasattr(db, "_user_resources_hooks_registered"):
+            return
+        db._user_resources_hooks_registered = True
+
+        # the keys are going to be the sessions, the values are going to be
+        # the sets of dirty/deleted models
+        updated_users = defaultdict(lambda: list())
+        updated_roles = defaultdict(lambda: list())
+        deleted_users = defaultdict(lambda: list())
+        deleted_roles = defaultdict(lambda: list())
+
+        def _clear_dirty_sets(session):
+            """Clear the dirty sets for the given session."""
+            sid = id(session)
+            updated_users.pop(sid, None)
+            updated_roles.pop(sid, None)
+            deleted_users.pop(sid, None)
+            deleted_roles.pop(sid, None)
+
+        @event.listens_for(db.session, "before_commit")
+        def _before_commit(session):
+            """Find out which entities need indexing before commit."""
+            # it seems that the {dirty,new,deleted} sets aren't populated
+            # in after_commit anymore, that's why we need to collect the
+            # information here
+            updated = set(session.dirty).union(set(session.new))
+            deleted = set(session.deleted)
+            sid = id(session)
+
+            try:
+                # session._model_changes is a dictionary that contains
+                # references to all entities changed in the transaction
+                # we use this because it seems like sometimes changes to
+                # models aren't listed in session.dirty, but are listed
+                # in this collection, especially with UserProfiles
+                changes = session._model_changes.values()
+                updated = updated.union(
+                    {m for (m, op) in changes if op == "update"}
+                )
+            except Exception as e:
+                # TODO
+                print("Something went wrong:", e)
+
+            # flush the session s.t. related models are queryable
+            session.flush()
+
+            # users need to be reindexed if their user model was updated, or
+            # their profile was changed (or even possibly deleted)
+            users1 = {u for u in updated if isinstance(u, User)}
+            users2 = {p.user for p in updated if isinstance(p, UserProfile)}
+            users3 = {p.user for p in deleted if isinstance(p, UserProfile)}
+
+            updated_users[sid] = list(users1.union(users2).union(users3))
+            updated_roles[sid] = [r for r in updated if isinstance(r, Role)]
+
+            deleted_users[sid] = [u for u in deleted if isinstance(u, User)]
+            deleted_roles[sid] = [r for r in deleted if isinstance(r, Role)]
+
+            # force loading of user profile before the commit is done
+            for user in updated_users[sid]:
+                user.profile is None  # noqa
+
+        @event.listens_for(db.session, "after_commit")
+        def _after_commit(session):
+            """Reindex all modified users and roles after the DB commit."""
+            # since this function is called after the commit, no more
+            # DB operations are allowed here, not even lazy-loading of
+            # properties!
+            sid = id(session)
+            for user in updated_users[sid]:
+                reindex_user(user)
+            for role in updated_roles[sid]:
+                reindex_group(role)
+
+            for user in deleted_users[sid]:
+                unindex_user(user)
+            for role in deleted_roles[sid]:
+                unindex_group(role)
+
+            _clear_dirty_sets(session)
+
+        @event.listens_for(db.session, "after_rollback")
+        def _after_rollback(session):
+            """When a session is rolled back, we don't reindex anything."""
+            _clear_dirty_sets(session)

--- a/invenio_users_resources/proxies.py
+++ b/invenio_users_resources/proxies.py
@@ -15,3 +15,13 @@ current_user_resources = LocalProxy(
     lambda: current_app.extensions["invenio-users-resources"]
 )
 """Proxy for the instantiated Users-Resources extension."""
+
+current_users_service = LocalProxy(
+    lambda: current_app.extensions["invenio-users-resources"].users_service
+)
+"""Proxy for the currently instantiated users service."""
+
+current_groups_service = LocalProxy(
+    lambda: current_app.extensions["invenio-users-resources"].groups_service
+)
+"""Proxy for the currently instantiated user groups service."""

--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -121,6 +121,7 @@ class UserAggregate(Record):
     def create(
         cls, data, id_=None, validator=None, format_checker=None, **kwargs
     ):
+        """Create a new User and store it in the database."""
         # NOTE: we don't use an actual database table, and as such can't
         #       use db.session.add(record.model)
         with db.session.begin_nested():

--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -102,21 +102,6 @@ class UserAggregate(Record):
 
     access = DictField("access")
 
-    _user = None
-    """The cached User entity."""
-
-    @property
-    def user(self):
-        """Cache for the associated user object."""
-        user = self._user
-        if user is None:
-            id_, email = self.id, self.email
-            user = current_datastore.get_user(id_ or email)
-
-            self._user = user
-
-        return user
-
     @classmethod
     def create(
         cls, data, id_=None, validator=None, format_checker=None, **kwargs
@@ -139,7 +124,7 @@ class UserAggregate(Record):
         """Update the aggregate data on commit."""
         # TODO this does not allow us to set properties via the UserAggregate?
         #      because everything's taken from the User object...
-        data = parse_user_data(self.user)
+        data = parse_user_data(self.model.model_obj)
         self.update(data)
         self.model.update(data)
         return self
@@ -150,9 +135,8 @@ class UserAggregate(Record):
         # TODO
         data = parse_user_data(user)
 
-        model = cls.model_cls(data)
+        model = cls.model_cls(data, model_obj=user)
         user_agg = cls(data, model=model)
-        user_agg._user = user
         return user_agg
 
     @classmethod
@@ -234,7 +218,7 @@ class GroupAggregate(Record):
         # TODO
         data = parse_role_data(role)
 
-        model = cls.model_cls(data)
+        model = cls.model_cls(data, model_obj=role)
         role_agg = cls(data, model=model)
         role_agg._role = role
         return role_agg

--- a/invenio_users_resources/records/dumpers/__init__.py
+++ b/invenio_users_resources/records/dumpers/__init__.py
@@ -10,4 +10,4 @@
 
 from .email import EmailFieldDumperExt
 
-__all__ = "EmailFieldDumperExt"
+__all__ = ("EmailFieldDumperExt",)

--- a/invenio_users_resources/records/models.py
+++ b/invenio_users_resources/records/models.py
@@ -8,8 +8,12 @@
 
 """Base model classes for user and group management in Invenio."""
 
+from abc import ABC, abstractmethod
 
-class MockModel(dict):
+from invenio_accounts.proxies import current_datastore
+
+
+class MockModel(dict, ABC):
     """Model class that does not correspondond to a database table.
 
     Since we already have all information about the required entities
@@ -20,10 +24,17 @@ class MockModel(dict):
     that's expected by API classes as far as necessary.
     """
 
-    def __init__(self, data=None, **kwargs):
+    def __init__(self, data=None, model_obj=None, **kwargs):
         """Constructor."""
         data.update(kwargs)
         super().__init__(data)
+        self._model_obj = model_obj
+
+    @property
+    @abstractmethod
+    def model_obj(self):
+        """The actual model object behind this mock model."""
+        return None
 
     @property
     def id(self):
@@ -33,14 +44,17 @@ class MockModel(dict):
     @property
     def created(self):
         """When the user was created."""
-        # TODO utcnow?
-        return None
+        return self.model_obj.created
 
     @property
     def updated(self):
         """When the user was last updated."""
-        # TODO same as above
-        return None
+        return self.model_obj.updated
+
+    @property
+    def version_id(self):
+        """Used by SQLAlchemy for optimistic concurrency control."""
+        return self.model_obj.version_id
 
     @property
     def data(self):
@@ -53,12 +67,6 @@ class MockModel(dict):
         return dict(self)
 
     @property
-    def version_id(self):
-        """Used by SQLAlchemy for optimistic concurrency control."""
-        # TODO
-        return 1
-
-    @property
     def is_deleted(self):
         """Boolean flag to determine if a user is soft deleted."""
         # TODO
@@ -68,6 +76,27 @@ class MockModel(dict):
 class UserAggregateModel(MockModel):
     """Mock model for glueing together various parts of user info."""
 
+    @property
+    def model_obj(self):
+        """The actual model object behind this mock model."""
+        if self._model_obj is None:
+            id_ = self.data.get("id")
+            email = self.data.get("email")
+            self._model_obj = current_datastore.get_user(id_ or email)
+        return self._model_obj
+
 
 class GroupAggregateModel(MockModel):
     """Mock model for glueing together various parts of user group info."""
+
+    @property
+    def model_obj(self):
+        """The actual model object behind this mock model."""
+        if self._model_obj is None:
+            id_ = self.data.get("id")
+            name = self.data.get("name")
+            if id_ is not None:
+                self._model_obj = current_datastore.role_model.query.get(id_)
+            elif name is not None:
+                self._model_obj = current_datastore.find_role(name)
+        return self._model_obj

--- a/invenio_users_resources/records/models.py
+++ b/invenio_users_resources/records/models.py
@@ -27,33 +27,40 @@ class MockModel(dict):
 
     @property
     def id(self):
+        """User identifier."""
         return self.data["id"]
 
     @property
     def created(self):
+        """When the user was created."""
         # TODO utcnow?
         return None
 
     @property
     def updated(self):
+        """When the user was last updated."""
         # TODO same as above
         return None
 
     @property
     def data(self):
+        """Get the user's data by decoding the JSON."""
         return dict(self)
 
     @property
     def json(self):
+        """Provide the user's data as a JSON/dict blob."""
         return dict(self)
 
     @property
     def version_id(self):
+        """Used by SQLAlchemy for optimistic concurrency control."""
         # TODO
         return 1
 
     @property
     def is_deleted(self):
+        """Boolean flag to determine if a user is soft deleted."""
         # TODO
         return False
 

--- a/invenio_users_resources/services/permissions.py
+++ b/invenio_users_resources/services/permissions.py
@@ -19,6 +19,7 @@ class IfPublicEmail(Generator):
     """Generator for different permissions based on the visibility settings."""
 
     def __init__(self, then_, else_):
+        """Constructor."""
         self.then_ = then_
         self.else_ = else_
 

--- a/invenio_users_resources/services/schemas.py
+++ b/invenio_users_resources/services/schemas.py
@@ -2,8 +2,9 @@
 #
 # Copyright (C) 2022 TU Wien.
 #
-# Invenio-Requests is free software; you can redistribute it and/or modify it
-# under the terms of the MIT License; see LICENSE file for more details.
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
 
 """User and user group schemas."""
 

--- a/invenio_users_resources/utils.py
+++ b/invenio_users_resources/utils.py
@@ -1,0 +1,36 @@
+# -*- coding: utf-8 -*-
+#
+# Copyright (C) 2022 TU Wien.
+#
+# Invenio-Users-Resources is free software; you can redistribute it and/or
+# modify it under the terms of the MIT License; see LICENSE file for more
+# details.
+
+"""Utility functions."""
+
+from .proxies import current_groups_service, current_users_service
+from .records.api import GroupAggregate, UserAggregate
+
+
+def reindex_user(user):
+    """Reindex the given user."""
+    user_agg = UserAggregate.from_user(user)
+    current_users_service.indexer.index(user_agg)
+
+
+def unindex_user(user):
+    """Delete the given user from the index."""
+    user_agg = UserAggregate.from_user(user)
+    current_users_service.indexer.delete(user_agg)
+
+
+def reindex_group(role):
+    """Reindex the given role/group."""
+    group_agg = GroupAggregate.from_role(role)
+    current_groups_service.indexer.index(group_agg)
+
+
+def unindex_group(role):
+    """Unindex the given role/group."""
+    group_agg = GroupAggregate.from_role(role)
+    current_groups_service.indexer.delete(group_agg)

--- a/setup.py
+++ b/setup.py
@@ -55,6 +55,7 @@ setup_requires = [
 ]
 
 install_requires = [
+    "invenio-accounts>=2.0.0dev0",
     "invenio-i18n>=1.3.1",
     "invenio-userprofiles>=1.2.4",
     "invenio-oauthclient>=1.5.4",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,16 +20,6 @@ from flask import Flask
 from flask_babelex import Babel
 
 from invenio_users_resources import InvenioUsersResources
-from invenio_users_resources.views import blueprint
-
-
-@pytest.fixture(scope="module")
-def celery_config():
-    """Override pytest-invenio fixture.
-
-    TODO: Remove this fixture if you add Celery support.
-    """
-    return {}
 
 
 @pytest.fixture(scope="module")


### PR DESCRIPTION
* use the timestamp and version information from the reworked user model
  for indexing purposes
* register ~~mapper~~ session event hooks for keeping the search indices up to date
  with the database model
* ~~experimental results seemed to show that the mapper events are only
  emitted in the db connection that issued the statements, and thus we
  should not have a problem with multiple event handlers firing for the
  same event~~

edit: reworked to use session events rather than mapper events because we want to reindex the entities if and only if the DB commit went through; still needs some more testing.