### PR TITLE
Bulk indexing for `rebuild_index`

### DIFF
--- a/invenio_users_resources/services/groups/service.py
+++ b/invenio_users_resources/services/groups/service.py
@@ -50,8 +50,7 @@ class GroupsService(RecordService):
 
     def rebuild_index(self, identity, uow=None):
         """Reindex all user groups managed by this service."""
-        for role in Role.query.all():
-            role_agg = self.record_cls.from_role(role)
-            self.indexer.index(role_agg)
+        roles = Role.query.all()
+        self.indexer.bulk_index([r.id for r in roles])
 
         return True

--- a/invenio_users_resources/services/users/service.py
+++ b/invenio_users_resources/services/users/service.py
@@ -99,8 +99,7 @@ class UsersService(RecordService):
 
     def rebuild_index(self, identity, uow=None):
         """Reindex all users managed by this service."""
-        for user in User.query.all():
-            user_agg = self.record_cls.from_user(user)
-            self.indexer.index(user_agg)
+        users = User.query.all()
+        self.indexer.bulk_index([u.id for u in users])
 
         return True


### PR DESCRIPTION
Make the `service.rebuild_index` method use bulk indexing rather than indexing each item individually.
This is related to https://github.com/inveniosoftware/invenio-records-resources/pull/419.

All the relevant requirements were already in place: `UserAggregate.get_record(id)`, and the `index` system field; same for groups.