### PR TITLE
migrate to flask babel

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -8,6 +8,10 @@
 Changes
 =======
 
+Version 1.1.0 (released 2023-03-02)
+
+- remove deprecated flask-babelex dependency and imports
+
 Version 1.0.2 (released 2022-12-01)
 
 - Add identity to links template expand method

--- a/invenio_users_resources/__init__.py
+++ b/invenio_users_resources/__init__.py
@@ -9,6 +9,6 @@
 
 """Invenio module providing management APIs for users and roles/groups."""
 
-__version__ = "1.0.2"
+__version__ = "1.1.0"
 
 __all__ = ("__version__",)

--- a/invenio_users_resources/services/groups/config.py
+++ b/invenio_users_resources/services/groups/config.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -9,7 +10,7 @@
 
 """User groups service configuration."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services import (
     RecordServiceConfig,
     SearchOptions,

--- a/invenio_users_resources/services/schemas.py
+++ b/invenio_users_resources/services/schemas.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 TU Wien.
+# Copyright (C) 2023 Graz University of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -8,7 +9,7 @@
 
 """User and user group schemas."""
 
-from flask_babelex import lazy_gettext as _
+from invenio_i18n import lazy_gettext as _
 from invenio_records_resources.services.records.schema import BaseRecordSchema
 from marshmallow import Schema, ValidationError, fields
 from marshmallow_utils.permissions import FieldPermissionsMixin

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -26,7 +26,7 @@ function cleanup() {
 trap cleanup EXIT
 
 python -m check_manifest
-python -m setup extract_messages --dry-run
+python -m setup extract_messages --output-file /dev/null
 python -m sphinx.cmd.build -qnNW docs docs/_build/html
 eval "$(docker-services-cli up --db ${DB:-postgresql} --search ${SEARCH:-opensearch} --cache ${CACHE:-redis} --mq ${MQ:-rabbitmq} --env)"
 python -m pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,8 +28,8 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     # OAuthClient brings in Invenio-Accounts and Invenio-I18N
-    invenio-oauthclient>=2.0.0,<3.0.0
-    invenio-records-resources>=1.0.0,<2.0.0
+    invenio-oauthclient>=2.2.0,<3.0.0
+    invenio-records-resources>=1.1.0,<2.0.0
 
 [options.extras_require]
 tests =


### PR DESCRIPTION
- migrate: flask_babelex replaced by invenio_i18n
- fix: --dry-run ignored

- NOTE: invenio-accounts invenio-admin invenio-files-rest invenio-i18n invenio-oauthclient invenio-pidstore invenio-records invenio-records-resources invenio-theme have to be released first