### PR TITLE
resolvers: added ghost record for groups.

### DIFF
--- a/invenio_users_resources/entity_resolvers.py
+++ b/invenio_users_resources/entity_resolvers.py
@@ -137,6 +137,16 @@ class GroupProxy(EntityProxy):
         role_id = self._parse_ref_dict_id()
         return [RoleNeed(role_id)]
 
+    def ghost_record(self, value):
+        """Return default representation of not resolved group.
+
+        .. note::
+
+            Only groups that are not indexed should need this. Non-indexed groups include groups that were not created by users
+            e.g. user-moderation.
+        """
+        return {}
+
 
 class GroupResolver(EntityResolver):
     """Group entity resolver."""


### PR DESCRIPTION
Note: The issue is that `user-administration` is not a group that is indexed in ES. Therefore, when expanding the moderation request the group can't be expanded and defaults to `ghost_record`. 