### PR TITLE
mappings: change "dynamic" values to string

### DIFF
--- a/invenio_users_resources/records/mappings/os-v1/domains/domain-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v1/domains/domain-v1.0.0.json
@@ -60,7 +60,7 @@
           "props" : {
             "type": "object",
             "properties": {},
-            "dynamic": true
+            "dynamic": "true"
           },
           "is_parent" : {
             "type": "boolean"

--- a/invenio_users_resources/records/mappings/os-v1/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v1/users/user-v1.0.0.json
@@ -111,7 +111,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "preferences": {
         "properties": {
@@ -137,7 +137,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_users_resources/records/mappings/os-v1/users/user-v2.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v1/users/user-v2.0.0.json
@@ -105,7 +105,7 @@
       "identities": {
         "type": "object",
         "properties": {},
-        "dynamic": true
+        "dynamic": "true"
       },
       "profile": {
         "properties": {
@@ -121,7 +121,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "preferences": {
         "properties": {
@@ -145,7 +145,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "status": {
         "type": "keyword"

--- a/invenio_users_resources/records/mappings/os-v2/domains/domain-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v2/domains/domain-v1.0.0.json
@@ -60,7 +60,7 @@
           "props" : {
             "type": "object",
             "properties": {},
-            "dynamic": true
+            "dynamic": "true"
           },
           "is_parent" : {
             "type": "boolean"

--- a/invenio_users_resources/records/mappings/os-v2/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v2/users/user-v1.0.0.json
@@ -115,7 +115,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "preferences": {
         "properties": {
@@ -141,7 +141,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_users_resources/records/mappings/os-v2/users/user-v2.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v2/users/user-v2.0.0.json
@@ -105,7 +105,7 @@
       "identities": {
         "type": "object",
         "properties": {},
-        "dynamic": true
+        "dynamic": "true"
       },
       "profile": {
         "properties": {
@@ -121,7 +121,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "preferences": {
         "properties": {
@@ -145,7 +145,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "status": {
         "type": "keyword"

--- a/invenio_users_resources/records/mappings/v7/domains/domain-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/v7/domains/domain-v1.0.0.json
@@ -60,7 +60,7 @@
           "props" : {
             "type": "object",
             "properties": {},
-            "dynamic": true
+            "dynamic": "true"
           },
           "is_parent" : {
             "type": "boolean"

--- a/invenio_users_resources/records/mappings/v7/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/v7/users/user-v1.0.0.json
@@ -115,7 +115,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "preferences": {
         "properties": {
@@ -141,7 +141,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       }
     }
   }

--- a/invenio_users_resources/records/mappings/v7/users/user-v2.0.0.json
+++ b/invenio_users_resources/records/mappings/v7/users/user-v2.0.0.json
@@ -105,7 +105,7 @@
       "identities": {
         "type": "object",
         "properties": {},
-        "dynamic": true
+        "dynamic": "true"
       },
       "profile": {
         "properties": {
@@ -121,7 +121,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "preferences": {
         "properties": {
@@ -145,7 +145,7 @@
             }
           }
         },
-        "dynamic": true
+        "dynamic": "true"
       },
       "status": {
         "type": "keyword"


### PR DESCRIPTION
- The mapping is stored as a string/enum in ES/OS. Using the same type
  makes sure the mapping comparison is correct when performing a
  mapping update.