### PR TITLE
moderation: add self-action prevention

### DIFF
--- a/invenio_users_resources/services/generators.py
+++ b/invenio_users_resources/services/generators.py
@@ -3,6 +3,7 @@
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022 CERN.
 # Copyright (C) 2023 Graz University of Technology.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 # Copyright (C) 2025 Ubiquity Press.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
@@ -91,6 +92,18 @@ class Self(Generator):
                 if need.method == "id":
                     return dsl.Q("term", id=need.value)
 
+        return []
+
+
+class PreventSelf(Generator):
+    """Prevents users from performing actions on themselves."""
+
+    def excludes(self, record=None, actor_id=None, **kwargs):
+        """Exclude needs to prevent self-actions."""
+        if record is None or actor_id is None:
+            return []
+        if actor_id == record.id:
+            return [UserNeed(record.id)]
         return []
 
 

--- a/invenio_users_resources/services/permissions.py
+++ b/invenio_users_resources/services/permissions.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 TU Wien.
+# Copyright (C) 2024 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -23,6 +24,7 @@ from .generators import (
     IfGroupNotManaged,
     IfPublicEmail,
     IfPublicUser,
+    PreventSelf,
     Self,
 )
 
@@ -51,10 +53,10 @@ class UsersPermissionPolicy(BasePermissionPolicy):
     can_read_all = [UserManager, SystemProcess()]
 
     # Moderation permissions
-    can_manage = [UserManager, SystemProcess()]
+    can_manage = [UserManager, PreventSelf(), SystemProcess()]
     can_search_all = [UserManager, SystemProcess()]
     can_read_system_details = [UserManager, SystemProcess()]
-    can_impersonate = [UserManager, SystemProcess()]
+    can_impersonate = [UserManager, PreventSelf(), SystemProcess()]
 
 
 class GroupsPermissionPolicy(BasePermissionPolicy):

--- a/invenio_users_resources/services/users/service.py
+++ b/invenio_users_resources/services/users/service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2022 KTH Royal Institute of Technology
+# Copyright (C) 2022-2024 KTH Royal Institute of Technology.
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022 European Union.
 # Copyright (C) 2022 CERN.
@@ -129,6 +129,12 @@ class UsersService(RecordService):
         self.indexer.bulk_index([u.id for u in users])
         return True
 
+    def _check_permission(self, identity, permission_type, user):
+        """Checks if given identity has the specified permission type on the user."""
+        self.require_permission(
+            identity, permission_type, record=user, actor_id=identity.id
+        )
+
     @unit_of_work()
     def block(self, identity, id_, uow=None):
         """Blocks a user."""
@@ -136,8 +142,7 @@ class UsersService(RecordService):
         if user is None:
             # return 403 even on empty resource due to security implications
             raise PermissionDeniedError()
-
-        self.require_permission(identity, "manage", record=user)
+        self._check_permission(identity, "manage", user)
 
         if user.blocked:
             raise ValidationError("User is already blocked.")
@@ -160,8 +165,7 @@ class UsersService(RecordService):
         if user is None:
             # return 403 even on empty resource due to security implications
             raise PermissionDeniedError()
-
-        self.require_permission(identity, "manage", record=user)
+        self._check_permission(identity, "manage", user)
 
         if not user.blocked:
             raise ValidationError("User is not blocked.")
@@ -185,8 +189,7 @@ class UsersService(RecordService):
         if user is None:
             # return 403 even on empty resource due to security implications
             raise PermissionDeniedError()
-
-        self.require_permission(identity, "manage", record=user)
+        self._check_permission(identity, "manage", user)
 
         if user.verified:
             raise ValidationError("User is already verified.")
@@ -209,7 +212,7 @@ class UsersService(RecordService):
         if user is None:
             # return 403 even on empty resource due to security implications
             raise PermissionDeniedError()
-        self.require_permission(identity, "manage", record=user)
+        self._check_permission(identity, "manage", user)
 
         if not user.active:
             raise ValidationError("User is already inactive.")
@@ -225,7 +228,8 @@ class UsersService(RecordService):
         if user is None:
             # return 403 even on empty resource due to security implications
             raise PermissionDeniedError()
-        self.require_permission(identity, "manage", record=user)
+        self._check_permission(identity, "manage", user)
+
         if user.active and user.confirmed:
             raise ValidationError("User is already active.")
         user.activate()
@@ -238,5 +242,6 @@ class UsersService(RecordService):
         if user is None:
             # return 403 even on empty resource due to security implications
             raise PermissionDeniedError()
-        self.require_permission(identity, "impersonate", record=user)
+        self._check_permission(identity, "impersonate", user)
+
         return user.model.model_obj

--- a/tests/resources/test_resources_users.py
+++ b/tests/resources/test_resources_users.py
@@ -127,6 +127,10 @@ def test_approve_user(client, headers, user_pub, user_moderator, db):
     assert res.status_code == 200
     assert res.json["verified_at"] is not None
 
+    # Test user tries to approve themselves
+    res = client.post(f"/users/{user_moderator.id}/approve", headers=headers)
+    assert res.status_code == 403
+
 
 def test_block_user(client, headers, user_pub, user_moderator, db):
     """Tests block user endpoint."""
@@ -138,6 +142,13 @@ def test_block_user(client, headers, user_pub, user_moderator, db):
     assert res.status_code == 200
     assert res.json["blocked_at"] is not None
 
+    # Test user tries to block themselves
+    res = client.post(f"/users/{user_moderator.id}/block", headers=headers)
+    assert res.status_code == 403
+
+    res = client.get(f"/users/{user_moderator.id}")
+    assert res.status_code == 200
+
 
 def test_deactivate_user(client, headers, user_pub, user_moderator, db):
     """Tests deactivate user endpoint."""
@@ -148,6 +159,13 @@ def test_deactivate_user(client, headers, user_pub, user_moderator, db):
     res = client.get(f"/users/{user_pub.id}")
     assert res.status_code == 200
     assert res.json["active"] == False
+
+    # Test user tries to deactivate themselves
+    res = client.post(f"/users/{user_moderator.id}/deactivate", headers=headers)
+    assert res.status_code == 403
+
+    res = client.get(f"/users/{user_moderator.id}")
+    assert res.status_code == 200
 
 
 def test_management_permissions(client, headers, user_pub, db):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* The problem is that an admin could block his own account. With this change, it is possible to prevent the admin from doing that.
* Prevent self-action for: `block`, `deactivate`, `restore`, `activate`, `impersonate` and `approve`.
* Update tests for self-action prevention
* introduce the PreventSelf generator
* introduce `_check_permission` in users service
* add "PreventSelf" into `can_manage` and `can_impersonate` permission
* closes <https://github.com/inveniosoftware/invenio-administration/issues/203>


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [x] I've added relevant test cases.
- [x] I've added relevant documentation.
- [x] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [x] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect](https://github.com/orgs/inveniosoftware/teams/architects/members).

**Frontend**

- [x] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [x] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [x] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
