### PR TITLE
resolvers: use the role ID rather than name to resolve the entity

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -73,7 +73,7 @@ jobs:
           pip install ".[$EXTRAS]"
           pip freeze
           docker --version
-          docker-compose --version
+          docker compose version
 
       - name: Run tests
         run: |

--- a/invenio_users_resources/entity_resolvers.py
+++ b/invenio_users_resources/entity_resolvers.py
@@ -123,9 +123,7 @@ class GroupProxy(EntityProxy):
         # Resolves to role name, not id
         role_id = self._parse_ref_dict_id()
         try:
-            return Role.query.filter(
-                Role.name == role_id  # TODO to be changed to role id
-            ).one()
+            return Role.query.filter(Role.id == role_id).one()
         except NoResultFound:
             return {}
 


### PR DESCRIPTION
The `GroupResolver` already uses the role ID rather than their name for creating reference dictionaries.

# More context

More context, as taken from the [Discord server](https://discord.com/channels/692989811736182844/1035104382519365712/1270076890471727206):

> hey, i've been trying out tu-graz-library/invenio-curations for a bit and it looks like the creation of curation requests is failing, as that uses roles (groups) as receivers
digging a little bit deeper, it looks like the root cause is a mismatch between using role.id and role.name for creating reference dicts and resolution of them later:

> the creation of reference dicts for groups uses entity.id: https://github.com/inveniosoftware/invenio-users-resources/blob/master/invenio_users_resources/entity_resolvers.py#L176
but the resolution queries the database based on Role.name: https://github.com/inveniosoftware/invenio-users-resources/blob/master/invenio_users_resources/entity_resolvers.py#L127

> this entails that the basic axiom of resolve(reference(x)) == x fails:

```python
In [17]: from invenio_requests.services.results import ResolverRegistry

In [18]: admin_role
Out[18]: <Role 1>

In [19]: ResolverRegistry.resolve_entity(ResolverRegistry.reference_entity(admin_role))
Out[19]: {}

In [20]: ResolverRegistry.resolve_entity(ResolverRegistry.reference_entity(a)) == admin_role
Out[20]: False
```

> the version in use for our local install is invenio-users-resources v5.2.0, but the above linked code is the same for later versions