### PR TITLE
fix administration dep

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,9 +11,12 @@ name: CI
 
 on:
   push:
-    branches: master
+    branches:
+      - master
   pull_request:
-    branches: master
+    branches:
+      - master
+      - "maint-**"
   schedule:
     # * is a special character in YAML so you have to quote this string
     - cron: "0 3 * * 6"
@@ -26,55 +29,4 @@ on:
 
 jobs:
   Tests:
-    runs-on: ubuntu-20.04
-    strategy:
-      matrix:
-        # You can add/remove combinations e.g. `dev` requirements or `postgresql13` by adding
-        # a new item to the following lists.
-        # You can see the complete list of services and versions that are available at:
-        # https://docker-services-cli.readthedocs.io/en/latest/configuration.html
-        python-version: [3.8, 3.9]
-        requirements-level: [pypi]
-        cache-service: [redis]
-        db-service: [postgresql14]
-        mq-service: [rabbitmq]
-        search-service: [opensearch2]
-
-    env:
-      CACHE: ${{ matrix.cache-service }}
-      DB: ${{ matrix.db-service }}
-      MQ: ${{ matrix.mq-service }}
-      SEARCH: ${{ matrix.search-service }}
-      EXTRAS: tests,${{matrix.search-service}}
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Generate dependencies
-        run: |
-          pip install wheel requirements-builder
-          requirements-builder -e "$EXTRAS" --level=${{ matrix.requirements-level }} setup.py > .${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt
-
-      - name: Cache pip
-        uses: actions/cache@v2
-        with:
-          path: ~/.cache/pip
-          key: ${{ runner.os }}-pip-${{ hashFiles('.${{ matrix.requirements-level }}-${{ matrix.python-version }}-requirements.txt') }}
-
-      - name: Install dependencies
-        run: |
-          pip install -r .${{matrix.requirements-level}}-${{ matrix.python-version }}-requirements.txt
-          pip install ".[$EXTRAS]"
-          pip freeze
-          docker --version
-          docker-compose --version
-
-      - name: Run tests
-        run: |
-          ./run-tests.sh
+    uses: inveniosoftware/workflows/.github/workflows/tests-python.yml@master

--- a/setup.cfg
+++ b/setup.cfg
@@ -27,7 +27,6 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    invenio-administration>=2.0.0,<3.0.0
     invenio-accounts>=5.0.0,<6.0.0
     invenio-i18n>=2.0.0
     invenio-notifications>=0.1.0,<1.0.0


### PR DESCRIPTION
- setup: remove unused dependency
- ci: use reusable workflows


NOTE:
- this fix should fix the problem with the newly introduced invenio-users-resource dependency in invenio-accounts
- there exists now a circular dependency between invenio-users-resources and invenio-accounts

solutions:
- one solution would be to move the newly added cli to invenio-users-resources but i am not sure if a cli should be in a '*-resources'  package
- the other solution would be to move the models which are used in users-resources to users-resources
- the last solution would be to live with the circular dependency