### PR TITLE
fix: LegacyAPIWarning of sqlalchemy

### DIFF
--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2024 Graz University of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -315,7 +316,7 @@ class GroupAggregate(BaseAggregate):
         """Get the user group via the specified ID."""
         # TODO how do we want to resolve the roles? via ID or name?
         with db.session.no_autoflush:
-            role = current_datastore.role_model.query.get(id_)
+            role = db.session.get(current_datastore.role_model, id_)
             if role is None:
                 return None
             return cls.from_model(role)


### PR DESCRIPTION
* LegacyAPIWarning: The Query.get() method is considered legacy as of
  the 1.x series of SQLAlchemy and becomes a legacy construct in 2.0.
  The method is now available as Session.get() (deprecated since:
  2.0) (Background on SQLAlchemy 2.0 at: https://sqlalche.me/e/b8d9)
    role = current_datastore.role_model.query.get(id_)
