### PR TITLE
services: schemas: Add email field to system user

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,10 @@
 Changes
 =======
 
+Version v7.1.0 (released 2025-05-23)
+
+- schemas: add email to system user schema
+
 Version v7.0.0 (released 2025-02-13)
 
 - Remove pre-release status.

--- a/invenio_users_resources/__init__.py
+++ b/invenio_users_resources/__init__.py
@@ -10,6 +10,6 @@
 
 """Invenio module providing management APIs for users and roles/groups."""
 
-__version__ = "7.0.0"
+__version__ = "7.1.0"
 
 __all__ = ("__version__",)

--- a/invenio_users_resources/services/schemas.py
+++ b/invenio_users_resources/services/schemas.py
@@ -162,6 +162,7 @@ class SystemUserSchema(BaseGhostSchema):
         dump_only=True,
     )
     username = fields.Constant(_("System"), dump_only=True)
+    email = fields.Constant("noreply@inveniosoftware.org", dump_only=True)
 
 
 class NotificationPreferences(Schema):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,8 @@ def app_config(app_config):
 
     app_config["USERS_RESOURCES_GROUPS_ENABLED"] = True
 
+    app_config["THEME_FRONTPAGE"] = False
+
     return app_config
 
 


### PR DESCRIPTION
* When the entity resolver returns the system user, it doesn't contain the email which is required for audit logs

closes: https://github.com/CERNDocumentServer/cds-rdm/issues/359
related: https://github.com/inveniosoftware/invenio-audit-logs/issues/4