### PR TITLE
refactor: move to context_identity

### DIFF
--- a/invenio_users_resources/services/schemas.py
+++ b/invenio_users_resources/services/schemas.py
@@ -10,6 +10,7 @@
 """User and user group schemas."""
 
 from flask import current_app
+from invenio_access.context import context_identity
 from invenio_access.permissions import system_user_id
 from invenio_accounts.models import DomainCategory
 from invenio_accounts.profiles.schemas import (
@@ -117,7 +118,7 @@ class UserSchema(BaseRecordSchema, FieldPermissionsMixin):
 
     def is_self(self, obj):
         """Determine if identity is the current identity."""
-        current_identity = self.context["identity"]
+        current_identity = context_identity.get()
 
         _id = obj.get("id") or obj.id
 


### PR DESCRIPTION
* this change enables migration to marshmallow>=4.0 by fixing
  deprecation warning about removing context usage
