### PR TITLE
fix(entity_resolvers): handle `None` user entity

### DIFF
--- a/invenio_users_resources/entity_resolvers.py
+++ b/invenio_users_resources/entity_resolvers.py
@@ -47,8 +47,10 @@ class UserProxy(EntityProxy):
         user_id = self._parse_ref_dict_id()
         if user_id == system_user_id:
             return [system_process]
-        else:
+        elif isinstance(user_id, str) and user_id.isdigit():
             return [UserNeed(int(user_id))]
+        else:
+            return []
 
     def ghost_record(self, value):
         """Return default representation of not resolved user."""


### PR DESCRIPTION
This is needed, because in some request types with anonymous/guest users, we might end up storing `{"user": None}` as a reference... This is not ideal, but returning an empty list at least keeps downstream usage of the function type-safe.