### PR TITLE
fix: increase groups search max result window

### DIFF
--- a/invenio_users_resources/services/groups/config.py
+++ b/invenio_users_resources/services/groups/config.py
@@ -40,7 +40,7 @@ class GroupSearchOptions(SearchOptions):
 
     pagination_options = {
         "default_results_per_page": 20,
-        "default_max_results": 50,
+        "default_max_results": 10_000,
     }
 
     query_parser_cls = QueryParser.factory(fields=["id", "name"])


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* When admin selects page size 50, navigating to page 2 sends size=50&page=2, 
  which exceeds that window and raises QuerystringValidationError: Invalid pagination parameters.
  this change fix that.
* match the max result for users: https://github.com/inveniosoftware/invenio-users-resources/blob/7f982dc5d738f37c7a56b5e5861d0055366e7cf8/invenio_users_resources/services/users/config.py#L110



### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
