### PR TITLE
feat(users)!: backend for managing user roles in admin panel

### DIFF
--- a/invenio_users_resources/config.py
+++ b/invenio_users_resources/config.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2022 CERN.
 # Copyright (C) 2022 TU Wien.
-# Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2025-2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -53,7 +53,14 @@ USERS_RESOURCES_SERVICE_SCHEMA = UserSchema
 
 USERS_RESOURCES_SEARCH = {
     "sort": ["bestmatch", "username", "email", "domain", "newest", "oldest", "updated"],
-    "facets": ["status", "visibility", "domain_status", "domain", "affiliations"],
+    "facets": [
+        "status",
+        "visibility",
+        "domain_status",
+        "domain",
+        "affiliations",
+        "roles",
+    ],
 }
 """User search configuration."""
 
@@ -118,6 +125,15 @@ USERS_RESOURCES_SEARCH_FACETS = {
         "facet": facets.visibility,
         "ui": {
             "field": "visibility",
+        },
+    },
+    "roles": {
+        "facet": facets.roles,
+        "facet_options": {
+            "size": 100,
+        },
+        "ui": {
+            "field": "roles",
         },
     },
 }

--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -4,7 +4,7 @@
 # Copyright (C) 2022 CERN.
 # Copyright (C) 2024 Graz University of Technology.
 # Copyright (C) 2024 Ubiquity Press.
-# Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2025-2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -17,6 +17,7 @@ from collections import namedtuple
 from datetime import datetime
 
 from flask import current_app
+from invenio_access import ActionRoles, superuser_access
 from invenio_accounts.models import Domain, User
 from invenio_accounts.proxies import current_datastore
 from invenio_db import db
@@ -27,7 +28,7 @@ from invenio_records.systemfields import ModelField
 from invenio_records_resources.records.api import Record
 from invenio_records_resources.records.systemfields import IndexField
 from marshmallow import ValidationError
-from sqlalchemy import select
+from sqlalchemy import or_, select
 from sqlalchemy.exc import NoResultFound
 
 from .dumpers import EmailFieldDumperExt
@@ -41,6 +42,7 @@ from .systemfields import (
     DomainStatusNameField,
     IsNotNoneField,
     UserIdentitiesField,
+    UserRolesField,
 )
 
 EmulatedPID = namedtuple("EmulatedPID", ["pid_value"])
@@ -242,6 +244,9 @@ class UserAggregate(BaseAggregate):
     identities = UserIdentitiesField("identities", use_cache=True, index=True)
     """User identities."""
 
+    roles = UserRolesField("roles", index=True)
+    """User role names."""
+
     @property
     def avatar_chars(self):
         """Get avatar characters for user."""
@@ -306,6 +311,125 @@ class UserAggregate(BaseAggregate):
         if user is None:
             return False
         return current_datastore.deactivate_user(user)
+
+    def get_groups(self):
+        """Return assigned group role model objects."""
+        return sorted(self.model.model_obj.roles, key=lambda role: role.name)
+
+    def group_ids(self):
+        """Return assigned group IDs."""
+        return [str(group.id) for group in self.get_groups()]
+
+    def add_group(self, group_id):
+        """Add group membership to user if not already assigned."""
+        self.add_groups([group_id])
+        return self
+
+    def remove_group(self, group_id):
+        """Remove group membership from user if assigned."""
+        self.remove_groups([group_id])
+        return self
+
+    def _resolve_groups_to_roles(self, group_ids):
+        """Resolve group identifiers (ID or name) to role model objects."""
+        normalized_group_ids = []
+        for group_id in group_ids:
+            normalized = str(group_id).strip()
+            if normalized and normalized not in normalized_group_ids:
+                normalized_group_ids.append(normalized)
+
+        if not normalized_group_ids:
+            return []
+
+        role_model = current_datastore.role_model
+        group_roles = (
+            db.session.query(role_model)
+            .filter(
+                or_(
+                    role_model.id.in_(normalized_group_ids),
+                    role_model.name.in_(normalized_group_ids),
+                )
+            )
+            .all()
+        )
+        group_roles_by_id = {
+            str(group_role.id): group_role for group_role in group_roles
+        }
+        group_roles_by_name = {
+            str(group_role.name): group_role for group_role in group_roles
+        }
+
+        resolved_group_roles = []
+        seen_group_role_ids = set()
+        for group_id in normalized_group_ids:
+            group_role = group_roles_by_id.get(group_id) or group_roles_by_name.get(
+                group_id
+            )
+            if group_role is None:
+                raise ValidationError({"groups": [_("Group does not exist.")]})
+            group_role_id = str(group_role.id)
+            if group_role_id in seen_group_role_ids:
+                continue
+            seen_group_role_ids.add(group_role_id)
+            resolved_group_roles.append(group_role)
+        return resolved_group_roles
+
+    def resolve_group_ids(self, group_ids, require=False):
+        """Resolve group identifiers (ID or name) to canonical group IDs."""
+        resolved_group_ids = [
+            str(role.id) for role in self._resolve_groups_to_roles(group_ids)
+        ]
+        if require and not resolved_group_ids:
+            raise ValidationError({"groups": [_("Group ID cannot be empty.")]})
+        return resolved_group_ids
+
+    def add_groups(self, group_ids):
+        """Add multiple group memberships to user if not already assigned."""
+        user = self.model.model_obj
+
+        added = []
+        for group_role in self._resolve_groups_to_roles(group_ids):
+            if current_datastore.add_role_to_user(user, group_role):
+                added.append(str(group_role.id))
+
+        return {
+            "added": sorted(added),
+            "removed": [],
+            "groups": self.group_ids(),
+        }
+
+    def remove_groups(self, group_ids):
+        """Remove multiple group memberships from user if assigned."""
+        user = self.model.model_obj
+
+        removed = []
+        for group_role in self._resolve_groups_to_roles(group_ids):
+            if current_datastore.remove_role_from_user(user, group_role):
+                removed.append(str(group_role.id))
+
+        return {
+            "added": [],
+            "removed": sorted(removed),
+            "groups": self.group_ids(),
+        }
+
+    def set_groups(self, group_ids):
+        """Replace group memberships for a user."""
+        requested_groups = self._resolve_groups_to_roles(group_ids)
+        requested_group_ids = {str(group.id) for group in requested_groups}
+        current_group_ids = set(self.group_ids())
+
+        to_add = requested_group_ids - current_group_ids
+        to_remove = current_group_ids - requested_group_ids
+
+        self.add_groups(to_add)
+        self.remove_groups(to_remove)
+
+        return {
+            "added": sorted(to_add),
+            "removed": sorted(to_remove),
+            "groups": self.group_ids(),
+        }
 
     @classmethod
     def get_record(cls, id_):
@@ -382,6 +506,23 @@ class GroupAggregate(BaseAggregate):
         version = self.model.version_id or 0
         updated_ts = int(self.model.updated.timestamp()) if self.model.updated else 0
         return max(version + 1, updated_ts)
+
+    @classmethod
+    def superadmin_group_ids(cls):
+        """Return group IDs that grant superuser access."""
+        return {
+            str(action_role.role_id)
+            for action_role in ActionRoles.query_by_action(superuser_access).all()
+        }
+
+    @classmethod
+    def available_groups(cls, exclude_group_ids=None):
+        """Return groups available for assignment."""
+        role_model = current_datastore.role_model
+        query = db.session.query(role_model).order_by(role_model.name)
+        if exclude_group_ids:
+            query = query.filter(role_model.id.notin_(exclude_group_ids))
+        return query.all()
 
     @classmethod
     def get_record(cls, id_):

--- a/invenio_users_resources/records/hooks.py
+++ b/invenio_users_resources/records/hooks.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2022 CERN.
 # Copyright (C) 2022 TU Wien.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -15,6 +16,18 @@ from invenio_accounts.proxies import current_db_change_history
 from ..services.domains.tasks import delete_domains, reindex_domains
 from ..services.groups.tasks import reindex_groups, unindex_groups
 from ..services.users.tasks import reindex_users, unindex_users
+
+
+def _role_user_ids(role):
+    """Safely collect user IDs linked to a role."""
+    if role is None:
+        return []
+
+    try:
+        users = getattr(role, "users", []) or []
+        return [user.id for user in users if getattr(user, "id", None) is not None]
+    except (AttributeError, TypeError):
+        return []
 
 
 def pre_commit(sender, session):
@@ -37,6 +50,8 @@ def pre_commit(sender, session):
             current_db_change_history.add_updated_user(sid, item.id)
         if isinstance(item, Role):
             current_db_change_history.add_updated_role(sid, item.id)
+            for user_id in _role_user_ids(item):
+                current_db_change_history.add_updated_user(sid, user_id)
         if isinstance(item, Domain):
             current_db_change_history.add_updated_domain(sid, item.id)
 
@@ -45,6 +60,8 @@ def pre_commit(sender, session):
             current_db_change_history.add_deleted_user(sid, item.id)
         if isinstance(item, Role):
             current_db_change_history.add_deleted_role(sid, item.id)
+            for user_id in _role_user_ids(item):
+                current_db_change_history.add_updated_user(sid, user_id)
         if isinstance(item, Domain):
             current_db_change_history.add_deleted_domain(sid, item.id)
 

--- a/invenio_users_resources/records/mappings/os-v1/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v1/users/user-v1.0.0.json
@@ -97,6 +97,9 @@
         "type": "keyword",
         "index": "false"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/mappings/os-v1/users/user-v2.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v1/users/user-v2.0.0.json
@@ -107,6 +107,9 @@
         "properties": {},
         "dynamic": "true"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/mappings/os-v1/users/user-v3.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v1/users/user-v3.0.0.json
@@ -175,6 +175,9 @@
         "properties": {},
         "dynamic": "true"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/mappings/os-v2/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v2/users/user-v1.0.0.json
@@ -101,6 +101,9 @@
         "type": "keyword",
         "index": "false"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/mappings/os-v2/users/user-v2.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v2/users/user-v2.0.0.json
@@ -107,6 +107,9 @@
         "properties": {},
         "dynamic": "true"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/mappings/os-v2/users/user-v3.0.0.json
+++ b/invenio_users_resources/records/mappings/os-v2/users/user-v3.0.0.json
@@ -175,6 +175,9 @@
         "properties": {},
         "dynamic": "true"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/mappings/v7/users/user-v1.0.0.json
+++ b/invenio_users_resources/records/mappings/v7/users/user-v1.0.0.json
@@ -101,6 +101,9 @@
         "type": "keyword",
         "index": "false"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/mappings/v7/users/user-v2.0.0.json
+++ b/invenio_users_resources/records/mappings/v7/users/user-v2.0.0.json
@@ -107,6 +107,9 @@
         "properties": {},
         "dynamic": "true"
       },
+      "roles": {
+        "type": "keyword"
+      },
       "profile": {
         "properties": {
           "full_name": {

--- a/invenio_users_resources/records/systemfields/__init__.py
+++ b/invenio_users_resources/records/systemfields/__init__.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2024 CERN
 # Copyright (C) 2024 Graz University of Technology.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -114,6 +115,19 @@ class UserIdentitiesField(CalculatedIndexedField):
         )
         data = {i.method: i.id for i in identities}
         return data
+
+
+class UserRolesField(CalculatedIndexedField):
+    """Get a user's role names."""
+
+    def calculate(self, user_record):
+        """Return sorted role names."""
+        role_names = [
+            role.name
+            for role in user_record.model.model_obj.roles
+            if getattr(role, "name", None) is not None
+        ]
+        return sorted(role_names)
 
 
 class DomainOrgField(CalculatedIndexedField):

--- a/invenio_users_resources/resources/users/config.py
+++ b/invenio_users_resources/resources/users/config.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -18,6 +19,7 @@ from invenio_records_resources.resources import (
     SearchRequestArgsSchema,
 )
 from invenio_records_resources.resources.errors import ErrorHandlersMixin
+from invenio_records_resources.services.errors import PermissionDeniedError
 from marshmallow import fields
 
 
@@ -27,6 +29,18 @@ class UsersSearchRequestArgsSchema(SearchRequestArgsSchema):
     is_active = fields.Boolean()
     is_blocked = fields.Boolean()
     is_verified = fields.Boolean()
+
+
+class UserGroupsActionSchema(ma.Schema):
+    """Schema for bulk user group assignment actions."""
+
+    groups = fields.List(fields.Str(), required=True)
+
+
+def handle_user_permission_error(err):
+    """Handle permission errors without logging exception traceback."""
+    response = HTTPJSONException(code=403, description=err.description)
+    return response.get_response()
 
 
 #
@@ -41,6 +55,7 @@ class UsersResourceConfig(RecordResourceConfig):
         "list": "",
         "search_all": "/all",
         "item": "/<id>",
+        "groups-list": "/<id>/groups",
         "item-avatar": "/<id>/avatar.svg",
         "approve": "/<id>/approve",
         "block": "/<id>/block",
@@ -58,6 +73,7 @@ class UsersResourceConfig(RecordResourceConfig):
 
     error_handlers = {
         **ErrorHandlersMixin.error_handlers,
+        PermissionDeniedError: handle_user_permission_error,
         LockAcquireFailed: create_error_handler(
             lambda e: (
                 HTTPJSONException(

--- a/invenio_users_resources/resources/users/resource.py
+++ b/invenio_users_resources/resources/users/resource.py
@@ -4,6 +4,7 @@
 # Copyright (C) 2022-2026 CERN.
 # Copyright (C) 2022 European Union.
 # Copyright (C) 2024 Ubiquity Press.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -30,6 +31,7 @@ from invenio_records_resources.resources.records.resource import (
 from invenio_records_resources.resources.records.utils import search_preference
 from invenio_records_resources.services.errors import PermissionDeniedError
 
+from .config import UserGroupsActionSchema
 from .errors import UserNotFoundError
 
 
@@ -57,6 +59,10 @@ class UsersResource(RecordResource):
             route("POST", routes["list"], self.create),
             route("GET", routes["item"], self.read),
             route("GET", routes["item-avatar"], self.avatar),
+            route("GET", routes["groups-list"], self.groups),
+            route("POST", routes["groups-list"], self.add_groups),
+            route("PUT", routes["groups-list"], self.set_groups),
+            route("DELETE", routes["groups-list"], self.remove_groups),
             route("POST", routes["approve"], self.approve),
             route("POST", routes["block"], self.block),
             route("POST", routes["restore"], self.restore),
@@ -124,6 +130,63 @@ class UsersResource(RecordResource):
             last_modified=avatar.last_modified,
             max_age=avatar.max_age,
         )
+
+    @request_view_args
+    def groups(self):
+        """Get group assignments for a user."""
+        data = self.service.get_groups(
+            id_=resource_requestctx.view_args["id"],
+            identity=g.identity,
+        )
+        return data, 200
+
+    def _load_groups_payload(self):
+        """Load group IDs from bulk groups payload."""
+        payload = UserGroupsActionSchema().load(resource_requestctx.data or {})
+        return payload["groups"]
+
+    @request_view_args
+    @request_data
+    def add_groups(self):
+        """Add groups to a user."""
+        id_ = resource_requestctx.view_args["id"]
+        group_ids = self._load_groups_payload()
+        data = self.service.add_groups(
+            id_=id_,
+            group_ids=group_ids,
+            identity=g.identity,
+        )
+        return data, 200
+
+    @request_view_args
+    @request_data
+    def set_groups(self):
+        """Set groups on a user."""
+        return self._set_groups_response()
+
+    def _set_groups_response(self):
+        """Set groups on a user and return a resource response."""
+        id_ = resource_requestctx.view_args["id"]
+        group_ids = self._load_groups_payload()
+        data = self.service.set_groups(
+            id_=id_,
+            group_ids=group_ids,
+            identity=g.identity,
+        )
+        return data, 200
+
+    @request_view_args
+    @request_data
+    def remove_groups(self):
+        """Remove groups from a user."""
+        id_ = resource_requestctx.view_args["id"]
+        group_ids = self._load_groups_payload()
+        data = self.service.remove_groups(
+            id_=id_,
+            group_ids=group_ids,
+            identity=g.identity,
+        )
+        return data, 200
 
     @request_view_args
     def approve(self):

--- a/invenio_users_resources/services/permissions.py
+++ b/invenio_users_resources/services/permissions.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2024 KTH Royal Institute of Technology.
 # Copyright (C) 2024 Ubiquity Press.
-# Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2025-2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -60,6 +60,13 @@ class UsersPermissionPolicy(BasePermissionPolicy):
     ]
     can_read_details = [UserManager, Self(), SystemProcess()]
     can_read_all = [UserManager, SystemProcess()]
+    can_read_user_groups = [
+        IfSuperAdmin(
+            then_=[SuperAdmin],
+            else_=[GroupManager, Self()],
+        ),
+        SystemProcess(),
+    ]
 
     # Moderation permissions
     can_manage = [UserManager, PreventSelf(), SystemProcess()]
@@ -78,6 +85,7 @@ class UsersPermissionPolicy(BasePermissionPolicy):
             then_=[SuperAdmin],
             else_=[GroupManager],
         ),
+        PreventSelf(),
         SystemProcess(),
     ]
 

--- a/invenio_users_resources/services/users/config.py
+++ b/invenio_users_resources/services/users/config.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022-2026 CERN.
-# Copyright (C) 2024 KTH Royal Institute of Technology.
+# Copyright (C) 2024-2026 KTH Royal Institute of Technology.
 # Copyright (C) 2025 Northwestern University.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
@@ -38,6 +38,7 @@ from invenio_records_resources.services.records.queryparser import (
 )
 from luqum.tree import Word
 
+from ...proxies import current_users_service
 from ...records.api import UserAggregate
 from ..common import EndpointLinkWithId, vars_func_set_querystring
 from ..params import FixedPagination
@@ -49,9 +50,24 @@ from .search_params import ModerationFilterParam
 
 def can_manage(obj, ctx):
     """Check if user can manage."""
-    from invenio_users_resources.proxies import current_users_service
-
     return current_users_service.check_permission(ctx["identity"], "manage")
+
+
+def can_manage_groups(obj, ctx):
+    """Check if user roles can be managed."""
+    identity = ctx["identity"]
+    actor_id = getattr(identity, "id", None)
+    user_id = getattr(obj, "id", None)
+    if actor_id is not None and user_id is not None and str(actor_id) == str(user_id):
+        return False
+
+    model = getattr(obj, "model", None)
+    if getattr(model, "_model_obj", None) is not None:
+        return current_users_service.check_permission(
+            identity, "manage_groups", record=obj, actor_id=actor_id
+        )
+
+    return current_users_service.check_permission(identity, "manage_groups")
 
 
 def word_domain_status(node):
@@ -144,6 +160,7 @@ class AdminUserSearchOptions(UserSearchOptions):
             "domaininfo.flagged",
             "domaininfo.tld",
             "domaininfo.category",
+            "roles",
         ],
         mapping={
             "affiliation": "profile.affiliations",
@@ -163,6 +180,8 @@ class AdminUserSearchOptions(UserSearchOptions):
             "domain.tld": "domaininfo.tld",
             "domain.category": "domaininfo.category",
             "domain.flagged": "domaininfo.flagged",
+            "role": "roles",
+            "roles": "roles",
         },
     )
 
@@ -240,6 +259,7 @@ class UsersServiceConfig(RecordServiceConfig, ConfiguratorMixin):
             ),
             when=can_manage,
         ),
+        "groups": EndpointLinkWithId("users.groups", when=can_manage_groups),
         # TODO missing moderation actions based on permissions
     }
 

--- a/invenio_users_resources/services/users/facets.py
+++ b/invenio_users_resources/services/users/facets.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2023 CERN.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Vocabularies is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -52,4 +53,10 @@ visibility = TermsFacet(
         "profile": _("Profile"),
         "full": _("Full"),
     },
+)
+
+roles = TermsFacet(
+    field="roles",
+    label=_("Roles"),
+    size=100,
 )

--- a/invenio_users_resources/services/users/results.py
+++ b/invenio_users_resources/services/users/results.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 TU Wien.
-# Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2025-2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -15,7 +15,17 @@ from invenio_records_resources.services.records.results import RecordItem, Recor
 def _role_names(user):
     """Return list of role names."""
     model = getattr(user, "model", user)
+    roles = getattr(model, "roles", None)
+    if isinstance(roles, list) and all(isinstance(role, str) for role in roles):
+        return roles
+
     model_obj = getattr(model, "_model_obj", model)
+
+    profile = getattr(model_obj, "profile", None)
+    if isinstance(profile, dict):
+        profile_roles = profile.get("roles")
+        if isinstance(profile_roles, list):
+            return [role for role in profile_roles if isinstance(role, str)]
 
     if not hasattr(model_obj, "roles"):
         model_obj = user
@@ -23,6 +33,9 @@ def _role_names(user):
     roles = getattr(model_obj, "roles", None)
     if not roles:
         return []
+
+    if isinstance(roles, list) and all(isinstance(role, str) for role in roles):
+        return roles
 
     return [role.name for role in roles]
 

--- a/invenio_users_resources/services/users/service.py
+++ b/invenio_users_resources/services/users/service.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 #
-# Copyright (C) 2022-2024 KTH Royal Institute of Technology.
+# Copyright (C) 2022-2026 KTH Royal Institute of Technology.
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022 European Union.
 # Copyright (C) 2022-2026 CERN.
@@ -16,7 +16,10 @@
 import secrets
 import string
 
+from flask import current_app
 from flask_security.utils import hash_password
+from invenio_access import Permission, superuser_access
+from invenio_access.permissions import system_process
 from invenio_accounts.models import User
 from invenio_accounts.proxies import current_datastore
 from invenio_accounts.utils import default_reset_password_link_func
@@ -28,12 +31,13 @@ from invenio_search.engine import dsl
 from marshmallow import ValidationError
 
 from invenio_users_resources.services.results import AvatarResult
+from invenio_users_resources.services.schemas import GroupSchema
 from invenio_users_resources.services.users.tasks import (
     execute_moderation_actions,
     execute_reset_password_email,
 )
 
-from ...records.api import UserAggregate
+from ...records.api import GroupAggregate, UserAggregate
 from .lock import ModerationMutex
 
 
@@ -171,6 +175,159 @@ class UsersService(RecordService):
         self.require_permission(
             identity, permission_type, record=user, actor_id=identity.id
         )
+
+    def _get_user_or_deny(self, id_):
+        """Load user or deny access when it does not exist."""
+        user = UserAggregate.get_record(id_)
+        if user is None:
+            raise PermissionDeniedError()
+        return user
+
+    def _can_manage_superadmin_roles(self, identity):
+        """Check if identity can mutate superadmin role memberships."""
+        return system_process in identity.provides or Permission(
+            superuser_access
+        ).allows(identity)
+
+    def _resolve_mutable_group_ids(self, identity, user, group_ids, require=False):
+        """Resolve and authorize group IDs for membership mutation."""
+        try:
+            resolved_group_ids = user.resolve_group_ids(group_ids, require=require)
+        except ValidationError as exc:
+            if require and not any(str(group_id).strip() for group_id in group_ids):
+                raise
+            raise PermissionDeniedError() from exc
+
+        return resolved_group_ids
+
+    def _deny_superadmin_group_mutation(self, identity, group_ids):
+        """Deny non-superadmins from changing superadmin role memberships."""
+        if (
+            group_ids
+            and not self._can_manage_superadmin_roles(identity)
+            and GroupAggregate.superadmin_group_ids().intersection(group_ids)
+        ):
+            raise PermissionDeniedError()
+
+    def _log_groups_update(self, identity, user, result):
+        """Log user group membership updates."""
+        current_app.logger.info(
+            "User '%s' updated user '%s' groups (added: %s, removed: %s)",
+            identity.id,
+            user.id,
+            result["added"],
+            result["removed"],
+        )
+
+    def get_groups(self, identity, id_):
+        """List group assignments and assignable groups for a user."""
+        user = self._get_user_or_deny(id_)
+        actor_id = getattr(identity, "id", None)
+        self.require_permission(
+            identity, "read_user_groups", record=user, actor_id=actor_id
+        )
+
+        groups = GroupSchema(many=True, only=("id", "name")).dump(user.get_groups())
+        can_manage_groups = self.check_permission(
+            identity, "manage_groups", record=user, actor_id=actor_id
+        )
+        excluded_group_ids = (
+            None
+            if self._can_manage_superadmin_roles(identity)
+            else GroupAggregate.superadmin_group_ids()
+        )
+        return {
+            "groups": groups,
+            "available_groups": (
+                GroupSchema(
+                    many=True, only=("id", "name", "description", "is_managed")
+                ).dump(GroupAggregate.available_groups(excluded_group_ids))
+                if can_manage_groups
+                else []
+            ),
+            "total": len(groups),
+        }
+
+    @unit_of_work()
+    def add_group(self, identity, id_, group_id, uow=None):
+        """Add a group to a user."""
+        user = self._get_user_or_deny(id_)
+        self._check_permission(identity, "manage_groups", user)
+
+        resolved_group_ids = self._resolve_mutable_group_ids(
+            identity, user, [group_id], require=True
+        )
+        self._deny_superadmin_group_mutation(identity, resolved_group_ids)
+        result = user.add_groups(resolved_group_ids)
+        self._log_groups_update(identity, user, result)
+        if result["added"]:
+            db.session.flush()
+            uow.register(RecordCommitOp(user, indexer=self.indexer, index_refresh=True))
+        return result
+
+    @unit_of_work()
+    def remove_group(self, identity, id_, group_id, uow=None):
+        """Remove a group from a user."""
+        user = self._get_user_or_deny(id_)
+        self._check_permission(identity, "manage_groups", user)
+
+        resolved_group_ids = self._resolve_mutable_group_ids(
+            identity, user, [group_id], require=True
+        )
+        self._deny_superadmin_group_mutation(identity, resolved_group_ids)
+        result = user.remove_groups(resolved_group_ids)
+        self._log_groups_update(identity, user, result)
+        if result["removed"]:
+            db.session.flush()
+            uow.register(RecordCommitOp(user, indexer=self.indexer, index_refresh=True))
+        return result
+
+    @unit_of_work()
+    def set_groups(self, identity, id_, group_ids, uow=None):
+        """Replace group memberships for a user."""
+        user = self._get_user_or_deny(id_)
+        self._check_permission(identity, "manage_groups", user)
+
+        resolved_group_ids = self._resolve_mutable_group_ids(identity, user, group_ids)
+        self._deny_superadmin_group_mutation(
+            identity, set(resolved_group_ids).symmetric_difference(user.group_ids())
+        )
+        result = user.set_groups(resolved_group_ids)
+        self._log_groups_update(identity, user, result)
+        if result["added"] or result["removed"]:
+            db.session.flush()
+            uow.register(RecordCommitOp(user, indexer=self.indexer, index_refresh=True))
+        return result
+
+    @unit_of_work()
+    def add_groups(self, identity, id_, group_ids, uow=None):
+        """Add multiple group memberships for a user without removing existing."""
+        user = self._get_user_or_deny(id_)
+        self._check_permission(identity, "manage_groups", user)
+
+        resolved_group_ids = self._resolve_mutable_group_ids(identity, user, group_ids)
+        self._deny_superadmin_group_mutation(identity, resolved_group_ids)
+        result = user.add_groups(resolved_group_ids)
+        self._log_groups_update(identity, user, result)
+        if result["added"]:
+            db.session.flush()
+            uow.register(RecordCommitOp(user, indexer=self.indexer, index_refresh=True))
+        return result
+
+    @unit_of_work()
+    def remove_groups(self, identity, id_, group_ids, uow=None):
+        """Remove multiple group memberships for a user."""
+        user = self._get_user_or_deny(id_)
+        self._check_permission(identity, "manage_groups", user)
+
+        resolved_group_ids = self._resolve_mutable_group_ids(identity, user, group_ids)
+        self._deny_superadmin_group_mutation(identity, resolved_group_ids)
+        result = user.remove_groups(resolved_group_ids)
+        self._log_groups_update(identity, user, result)
+        if result["removed"]:
+            db.session.flush()
+            uow.register(RecordCommitOp(user, indexer=self.indexer, index_refresh=True))
+        return result
 
     @unit_of_work()
     def block(self, identity, id_, uow=None, data=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -148,7 +148,13 @@ def auth_identity():
 
 
 @pytest.fixture(scope="module")
-def user_moderator(UserFixture, app, database, users, administration_group):
+def user_moderator(
+    UserFixture,
+    app,
+    database,
+    users,
+    administration_group,
+):
     """Admin user for requests."""
     moderator = users["user_moderator"]
     moderator.roles = [administration_group]

--- a/tests/resources/test_resources_users.py
+++ b/tests/resources/test_resources_users.py
@@ -2,7 +2,7 @@
 #
 # Copyright (C) 2022 European Union.
 # Copyright (C) 2022-2026 CERN.
-# Copyright (C) 2024 KTH Royal Institute of Technology.
+# Copyright (C) 2024-2026 KTH Royal Institute of Technology.
 # Copyright (C) 2024 Ubiquity Press.
 # Copyright (C) 2025 Northwestern University.
 #
@@ -232,6 +232,159 @@ def test_management_permissions(client, headers, user_pub, db):
     """Test permissions at the resource level."""
     client = user_pub.login(client)
     res = client.post(f"/users/{user_pub.id}/deactivate", headers=headers)
+    assert res.status_code == 403
+
+
+def test_user_groups_endpoints(client, headers, user_moderator, user_pub, group):
+    """Manage user roles through users groups endpoints."""
+    client = user_moderator.login(client)
+
+    res = client.get(f"/users/{user_pub.id}/groups", headers=headers)
+    assert res.status_code == 200
+    assert isinstance(res.json["groups"], list)
+
+    res = client.put(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["  it-dep  "]},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert res.json["added"] == ["it-dep"]
+
+    res = client.get(f"/users/{user_pub.id}/groups", headers=headers)
+    assert res.status_code == 200
+    assert "it-dep" in [group["id"] for group in res.json["groups"]]
+
+    res = client.delete(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["it-dep"]},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert res.json["removed"] == ["it-dep"]
+
+
+def test_user_groups_self_mutation_forbidden(client, headers, user_moderator):
+    """Users cannot mutate their own roles."""
+    client = user_moderator.login(client)
+    res = client.put(
+        f"/users/{user_moderator.id}/groups",
+        json={"groups": ["it-dep"]},
+        headers=headers,
+    )
+    assert res.status_code == 403
+
+
+def test_user_groups_bulk_set(client, headers, user_moderator, user_pub, group, group2):
+    """Bulk set roles via the groups endpoint."""
+    client = user_moderator.login(client)
+    res = client.put(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["it-dep", "hr-dep"]},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert sorted(res.json["added"]) == ["hr-dep", "it-dep"]
+    assert res.json["removed"] == []
+    assert sorted(res.json["groups"]) == ["hr-dep", "it-dep"]
+
+    res = client.put(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["hr-dep"]},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert res.json["added"] == []
+    assert res.json["removed"] == ["it-dep"]
+    assert res.json["groups"] == ["hr-dep"]
+
+
+def test_user_groups_bulk_add(client, headers, user_moderator, user_pub, group, group2):
+    """Bulk add roles appends without removing existing roles."""
+    client = user_moderator.login(client)
+    client.put(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["it-dep"]},
+        headers=headers,
+    )
+    res = client.post(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["it-dep", "hr-dep"]},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert res.json["added"] == ["hr-dep"]
+    assert res.json["removed"] == []
+    assert sorted(res.json["groups"]) == ["hr-dep", "it-dep"]
+
+
+def test_user_groups_bulk_remove(
+    client, headers, user_moderator, user_pub, group, group2
+):
+    """Bulk remove roles via a single request."""
+    client = user_moderator.login(client)
+    client.put(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["it-dep", "hr-dep"]},
+        headers=headers,
+    )
+    res = client.delete(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["it-dep"]},
+        headers=headers,
+    )
+    assert res.status_code == 200
+    assert res.json["added"] == []
+    assert res.json["removed"] == ["it-dep"]
+    assert res.json["groups"] == ["hr-dep"]
+
+
+def test_user_groups_bulk_validation_error(client, headers, user_moderator, user_pub):
+    """Bulk groups payload must be a list of strings."""
+    client = user_moderator.login(client)
+    res = client.put(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": "it-dep"},
+        headers=headers,
+    )
+    assert res.status_code == 400
+
+
+def test_user_groups_bulk_forbidden(client, headers, user_pub, user_res):
+    """Non-managers cannot bulk mutate roles."""
+    client = user_pub.login(client)
+    res = client.put(
+        f"/users/{user_res.id}/groups",
+        json={"groups": ["it-dep"]},
+        headers=headers,
+    )
+    assert res.status_code == 403
+
+
+def test_user_groups_superadmin_role_forbidden(
+    client, headers, user_moderator, user_pub, superadmin_group
+):
+    """Non-superadmins cannot assign superadmin roles through the API."""
+    client = user_moderator.login(client)
+    res = client.put(
+        f"/users/{user_pub.id}/groups",
+        json={"groups": ["admin"]},
+        headers=headers,
+    )
+    assert res.status_code == 403
+
+
+def test_user_groups_read_self_allowed(client, headers, user_pub):
+    """Users can read their own role assignments."""
+    client = user_pub.login(client)
+    res = client.get(f"/users/{user_pub.id}/groups", headers=headers)
+    assert res.status_code == 200
+
+
+def test_user_groups_read_forbidden(client, headers, user_pub, user_res):
+    """Non-managers cannot read role assignments of other users."""
+    client = user_pub.login(client)
+    res = client.get(f"/users/{user_res.id}/groups", headers=headers)
     assert res.status_code == 403
 
 

--- a/tests/services/test_generators.py
+++ b/tests/services/test_generators.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2025 Ubiquity Press.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -12,7 +13,7 @@ from invenio_access.utils import get_identity
 from invenio_records_permissions.generators import AuthenticatedUser
 
 from invenio_users_resources.permissions import user_management_action
-from invenio_users_resources.services.generators import IfGroupNotManaged
+from invenio_users_resources.services.generators import IfGroupNotManaged, PreventSelf
 from invenio_users_resources.services.permissions import UserManager
 
 
@@ -31,3 +32,10 @@ def test_group_not_managed_generator(app, user_pub, user_moderator):
     identity = get_identity(user_moderator)
     query = permission.query_filter(identity=identity)
     assert query.to_dict() == {"match_all": {}}
+
+
+def test_prevent_self_compares_ids_type_insensitively(user_pub):
+    """PreventSelf should block self-actions for str/int id mismatches."""
+    permission = PreventSelf()
+    excludes = permission.excludes(record=user_pub, actor_id=str(user_pub.id))
+    assert len(excludes) == 1

--- a/tests/services/users/test_service_users.py
+++ b/tests/services/users/test_service_users.py
@@ -2,6 +2,7 @@
 #
 # Copyright (C) 2022-2026 CERN.
 # Copyright (C) 2024 Ubiquity Press.
+# Copyright (C) 2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -10,6 +11,7 @@
 """User service tests."""
 
 import pytest
+from invenio_access.permissions import system_identity
 from invenio_records_resources.services.errors import PermissionDeniedError
 from marshmallow import ValidationError
 
@@ -73,6 +75,23 @@ def test_admin_search_field(user_service, user_moderator, query):
     """Make sure certain fields ARE searchable."""
     res = user_service.search_all(user_moderator.identity, q=query).to_dict()
     assert res["hits"]["total"] > 0
+
+
+def test_admin_search_filter_and_facet_roles(
+    user_service, user_moderator, user_pub, group
+):
+    """Admin search can filter/facet users by roles."""
+    user_service.add_group(user_moderator.identity, user_pub.id, "it-dep")
+    res = user_service.search_all(user_moderator.identity, q="roles:it-dep").to_dict()
+    assert str(user_pub.id) in [hit["id"] for hit in res["hits"]["hits"]]
+    assert "aggregations" in res
+    assert "roles" in res["aggregations"]
+
+
+def test_admin_roles_facet_size_configured(app):
+    """Roles facet should return many buckets, not just the default 10."""
+    roles_facet_config = app.config["USERS_RESOURCES_SEARCH_FACETS"]["roles"]
+    assert roles_facet_config["facet_options"]["size"] == 100
 
 
 # User search
@@ -443,3 +462,287 @@ def test_can_impersonate_user(
 
 
 # TODO Clear the cache to test actions without locking side-effects
+
+
+def test_add_group_normalizes_role_id(user_service, user_moderator, user_pub, group):
+    """Role IDs are normalized at service boundary."""
+    assert user_service.add_group(user_moderator.identity, user_pub.id, "  it-dep  ")
+    groups = user_service.get_groups(user_moderator.identity, user_pub.id)["groups"]
+    assert "it-dep" in [group["id"] for group in groups]
+
+
+def test_add_group_empty_role_id_validation(user_service, user_moderator, user_pub):
+    """Empty/blank role IDs fail with validation error."""
+    with pytest.raises(ValidationError):
+        user_service.add_group(user_moderator.identity, user_pub.id, "   ")
+
+
+def test_add_group_self_forbidden(user_service, user_moderator):
+    """Self role mutation is denied via manage_groups + PreventSelf."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.add_group(user_moderator.identity, user_moderator.id, "it-dep")
+
+
+def test_add_group_unknown_role_validation(user_service, user_moderator, user_pub):
+    """Unknown role IDs are denied to avoid role enumeration."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.add_group(user_moderator.identity, user_pub.id, "unknown-role-id")
+
+
+def test_remove_group_noop_when_role_missing(user_service, user_moderator, user_pub):
+    """Removing a non-member role is a no-op."""
+    assert user_service.remove_group(user_moderator.identity, user_pub.id, "it-dep")
+
+
+def test_set_groups_add_remove_mixed(
+    user_service, user_moderator, user_pub, group, group2
+):
+    """Bulk replacement adds and removes groups in one operation."""
+    user_service.set_groups(user_moderator.identity, user_pub.id, ["it-dep"])
+
+    result = user_service.set_groups(
+        user_moderator.identity,
+        user_pub.id,
+        ["hr-dep"],
+    )
+
+    assert result == {
+        "added": ["hr-dep"],
+        "removed": ["it-dep"],
+        "groups": ["hr-dep"],
+    }
+
+
+def test_add_groups_additive_no_removal(
+    user_service, user_moderator, user_pub, group, group2
+):
+    """Bulk add appends roles without removing existing memberships."""
+    user_service.set_groups(user_moderator.identity, user_pub.id, ["it-dep"])
+
+    result = user_service.add_groups(
+        user_moderator.identity,
+        user_pub.id,
+        ["it-dep", "hr-dep"],
+    )
+
+    assert result == {
+        "added": ["hr-dep"],
+        "removed": [],
+        "groups": ["hr-dep", "it-dep"],
+    }
+
+
+def test_set_groups_noop(user_service, user_moderator, user_pub, group):
+    """Bulk replacement is a no-op if requested roles are unchanged."""
+    user_service.set_groups(user_moderator.identity, user_pub.id, ["it-dep"])
+
+    result = user_service.set_groups(
+        user_moderator.identity,
+        user_pub.id,
+        ["it-dep"],
+    )
+
+    assert result == {
+        "added": [],
+        "removed": [],
+        "groups": ["it-dep"],
+    }
+
+
+def test_set_groups_normalizes_whitespace(
+    user_service, user_moderator, user_pub, group, group2
+):
+    """Bulk replacement normalizes IDs and ignores blanks."""
+    user_service.set_groups(user_moderator.identity, user_pub.id, [])
+
+    result = user_service.set_groups(
+        user_moderator.identity,
+        user_pub.id,
+        ["  it-dep  ", " ", "\thr-dep\t"],
+    )
+
+    assert result == {
+        "added": ["hr-dep", "it-dep"],
+        "removed": [],
+        "groups": ["hr-dep", "it-dep"],
+    }
+
+
+def test_set_groups_empty_clears_roles(
+    user_service, user_moderator, user_pub, group, group2
+):
+    """Bulk replacement with [] clears all roles."""
+    user_service.set_groups(user_moderator.identity, user_pub.id, ["it-dep", "hr-dep"])
+
+    result = user_service.set_groups(
+        user_moderator.identity,
+        user_pub.id,
+        [],
+    )
+
+    assert result == {
+        "added": [],
+        "removed": ["hr-dep", "it-dep"],
+        "groups": [],
+    }
+
+
+def test_group_mutation_advances_search_revision(
+    user_service, user_moderator, user_pub, group
+):
+    """Role-only mutations advance the revision used for search indexing."""
+    before_revision_id = user_service.record_cls.get_record(user_pub.id).revision_id
+
+    user_service.add_group(user_moderator.identity, user_pub.id, "it-dep")
+
+    after_revision_id = user_service.record_cls.get_record(user_pub.id).revision_id
+    assert after_revision_id > before_revision_id
+
+
+def test_set_groups_unknown_role_validation(user_service, user_moderator, user_pub):
+    """Unknown role IDs are denied to avoid role enumeration."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.set_groups(
+            user_moderator.identity,
+            user_pub.id,
+            ["unknown-role-id"],
+        )
+
+
+def test_set_groups_self_forbidden(user_service, user_moderator, group):
+    """Self role mutation is denied in bulk endpoint too."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.set_groups(user_moderator.identity, user_moderator.id, ["it-dep"])
+
+
+def test_get_groups_self_allowed(user_service, user_moderator):
+    """Users can read their own role list."""
+    result = user_service.get_groups(user_moderator.identity, user_moderator.id)
+    assert "groups" in result
+    assert "total" in result
+
+
+def test_get_groups_other_user_permission_denied(user_service, user_pub, user_res):
+    """Non-managers cannot read role list of other users."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.get_groups(user_pub.identity, user_res.id)
+
+
+def test_set_groups_permission_denied(user_service, user_pub, user_res, group):
+    """Non-managers cannot mutate groups of other users."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.set_groups(user_pub.identity, user_res.id, ["it-dep"])
+
+
+def test_superadmin_role_assignment_denied_for_non_superadmin(
+    user_service, user_moderator, user_pub, superadmin_group
+):
+    """Non-superadmins cannot grant superadmin role membership."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.add_group(user_moderator.identity, user_pub.id, "admin")
+
+
+def test_available_groups_excludes_superadmin_roles_for_non_superadmin(
+    user_service, user_moderator, user_pub, superadmin_group
+):
+    """Role management state does not advertise superadmin roles to managers."""
+    result = user_service.get_groups(user_moderator.identity, user_pub.id)
+    assert "admin" not in [role["id"] for role in result["available_groups"]]
+
+
+def test_set_groups_superadmin_removal_denied_for_non_superadmin(
+    user_service, user_moderator, user_pub, superadmin_group
+):
+    """Non-superadmins cannot remove superadmin membership via replacement."""
+    user_service.add_group(system_identity, user_pub.id, "admin")
+    try:
+        with pytest.raises(PermissionDeniedError):
+            user_service.set_groups(user_moderator.identity, user_pub.id, [])
+    finally:
+        user_service.remove_group(system_identity, user_pub.id, "admin")
+
+
+def test_remove_groups_bulk(user_service, user_moderator, user_pub, group, group2):
+    """Bulk remove deletes only requested assigned roles."""
+    user_service.set_groups(
+        user_moderator.identity,
+        user_pub.id,
+        ["it-dep", "hr-dep"],
+    )
+
+    result = user_service.remove_groups(
+        user_moderator.identity,
+        user_pub.id,
+        ["it-dep"],
+    )
+
+    assert result == {
+        "added": [],
+        "removed": ["it-dep"],
+        "groups": ["hr-dep"],
+    }
+
+
+def test_remove_groups_unknown_role_denied(user_service, user_moderator, user_pub):
+    """Unknown role IDs are denied in bulk remove too."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.remove_groups(
+            user_moderator.identity,
+            user_pub.id,
+            ["unknown-role-id"],
+        )
+
+
+def test_remove_groups_self_forbidden(user_service, user_moderator, group):
+    """Self bulk role removal is denied."""
+    with pytest.raises(PermissionDeniedError):
+        user_service.remove_groups(
+            user_moderator.identity, user_moderator.id, ["it-dep"]
+        )
+
+
+def test_set_groups_protected_role_allowed(
+    app, user_service, user_moderator, user_pub, user_res, group
+):
+    """Protected roles can be managed through user-role assignment endpoints."""
+    user_service.set_groups(user_moderator.identity, user_pub.id, ["it-dep"])
+
+    previous = app.config.get("USERS_RESOURCES_PROTECTED_GROUP_NAMES", [])
+    app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = ["it-dep"]
+    try:
+        result_remove = user_service.set_groups(
+            user_moderator.identity, user_pub.id, []
+        )
+        assert result_remove["removed"] == ["it-dep"]
+        result_add = user_service.set_groups(
+            user_moderator.identity, user_res.id, ["it-dep"]
+        )
+        assert result_add["added"] == ["it-dep"]
+    finally:
+        app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = previous
+
+
+def test_remove_protected_role_allowed_for_superadmin(
+    app, user_service, user_admin, user_pub
+):
+    """Superadmins can remove protected roles on other users."""
+    previous = app.config.get("USERS_RESOURCES_PROTECTED_GROUP_NAMES", [])
+    app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = ["admin"]
+    try:
+        user_service.add_group(system_identity, user_pub.id, "admin")
+        assert user_service.remove_group(user_admin.identity, user_pub.id, "admin")
+    finally:
+        app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = previous
+
+
+def test_add_protected_role_allowed_for_superadmin(
+    app, user_service, user_admin, user_pub
+):
+    """Superadmins can add protected roles on other users."""
+    previous = app.config.get("USERS_RESOURCES_PROTECTED_GROUP_NAMES", [])
+    app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = ["admin"]
+    try:
+        assert user_service.add_group(user_admin.identity, user_pub.id, "admin")
+    finally:
+        user_service.remove_group(system_identity, user_pub.id, "admin")
+        app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = previous


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

This PR adds backend support for administration user role management.

> Terminology note: the API uses the existing users-resources group terminology
   (`/users/<id>/groups` and payload key `groups`) because role memberships are
   represented internally as user groups/roles. The administration UI and search
   facets expose the same data as user roles, which is the administrator-facing
   concept.

It exposes permission-protected user role-assignment APIs, the resource link consumed by the administration UI, user-role indexing/search support, and logs role membership update operations.

### Main changes

- Add user role assignment service methods:
  - `get_groups()`
  - `set_groups()`
  - `add_groups()`
  - `remove_groups()`
- Add user role assignment resource endpoints under `/api/users/<id>/groups`.
- Expose permission-backed resource links for the administration UI.
- Prevent self role mutation.
- Resolve submitted roles by ID or name.
- Hide unknown role existence by returning permission denied for unresolved roles.
- Protect superadmin role memberships from non-superadmins.
- Log user role membership update operations, including actor user, target user, added roles, and removed roles.
- Add role names to user search indexing and facets.
- Reindex users when role memberships or role records change.
- Add/adjust resource and service tests for role assignment behavior.

Depends on: inveniosoftware/invenio-app-rdm#3354

### Breaking change

Users' index mapping now includes roles; a reindex is required: see: https://inveniordm.docs.cern.ch/releases/v12/upgrade-v12.0/#open-problems

If you can't afford to destroy and rebuild the indecies, this recipe is for you:

I tested this recipe locally, and it works:
###  Migrate users index (roles/IP facets missing)

Delete existing users indices:

```sh
# latest-build is my test instance name
curl -X DELETE 'http://localhost:9200/latest-build-users-user-v1.0.0-*'
curl -X DELETE 'http://localhost:9200/latest-build-users-user-v2.0.0-*'
curl -X DELETE 'http://localhost:9200/latest-build-users-user-v3.0.0-*'
```
Recreate users indices: `uv run invenio shell`

```py
from invenio_search.proxies import current_search

for item in current_search.create(ignore=[400], ignore_existing=True):
    if "users" in item[0]:
        print(item)

# Copy the generated v3 index name, e.g.:

INDEX = "latest-build-users-user-v3.0.0-1781015168"

Verify the mapping contains `roles`:

curl "http://localhost:9200/$INDEX/_mapping?pretty" | grep -A3 '"roles"'

# Reindex users:

from opensearchpy.helpers import bulk
from invenio_accounts.models import User
from invenio_users_resources.records.api import UserAggregate
from invenio_search.proxies import current_search_client

INDEX = "latest-build-users-user-v3.0.0-1781015168"

def actions():
    for user_model in User.query.yield_per(1000):
        record = UserAggregate.from_model(user_model)
        yield {
            "_op_type": "index",
            "_index": INDEX,
            "_id": str(record.id),
            "_source": record.dumps(),
        }

bulk(current_search_client, actions(), stats_only=True)
current_search_client.indices.refresh(index=INDEX)
```
###  Verify:

```sh
curl "http://localhost:9200/$INDEX/_count?pretty"

curl "http://localhost:9200/$INDEX/_search?pretty&size=0" \
  -H 'Content-Type: application/json' \
  -d '{"aggs":{"roles":{"terms":{"field":"roles","size":100}}}}'
```
Done.

### Administration UI integration

The companion `invenio-app-rdm` PR uses these APIs from the administration users list. The UI relies on backend resource links for permission-aware behavior:

- `links.groups` is rendered only when the current identity can manage the target user's roles.
- The same link gives the UI the state needed to populate the role-management modal.
- Replacement updates are submitted to `PUT /api/users/<user_id>/groups`.
- Self role mutation is forbidden.

### User Roles API

This PR introduces APIs for managing user role memberships with both bulk and incremental operations.

### 1. Read user role-management state

Method: `GET`  
URL: `/api/users/<user_id>/groups`  
Body: none

Example:

```http
GET /api/users/<user_id>/groups
```

Response:

```http
HTTP/1.1 200 OK
Content-Type: application/json
```

```json
{
  "groups": [
    {
      "id": "it-dep",
      "name": "it-dep"
    }
  ],
  "available_groups": [
    {
      "id": "hr-dep",
      "name": "hr-dep",
      "description": "Human resources",
      "is_managed": true
    }
  ],
  "total": 1
}
```

Notes:

- `groups` contains the roles currently assigned to the target user.
- `available_groups` contains assignable role options for the administration UI when the caller can manage the target user's roles.
- Users may read their own assigned groups.
- Reading another user's groups requires the administration/group-management permission.
- Assignable role options are only returned when the caller can manage the target user's roles.

### 2. Bulk replace roles

Method: `PUT`  
URL: `/api/users/<user_id>/groups`  
Semantics: final roles become exactly the submitted list.

Example:

```http
PUT /api/users/<user_id>/groups
Content-Type: application/json
```

```json
{
  "groups": ["it-dep", "hr-dep"]
}
```

Response:

```http
HTTP/1.1 200 OK
Content-Type: application/json
```

```json
{
  "added": ["hr-dep"],
  "removed": ["old-role"],
  "groups": ["hr-dep", "it-dep"]
}
```

### 3. Add roles without removing existing roles

Method: `POST`  
URL: `/api/users/<user_id>/groups`  
Semantics: add only roles not already assigned; keep existing roles untouched.

Example:

```http
POST /api/users/<user_id>/groups
Content-Type: application/json
```

```json
{
  "groups": ["it-dep", "hr-dep"]
}
```

Response:

```http
HTTP/1.1 200 OK
Content-Type: application/json
```

```json
{
  "added": ["hr-dep"],
  "removed": [],
  "groups": ["hr-dep", "it-dep"]
}
```

### 4. Remove specific roles

Method: `DELETE`  
URL: `/api/users/<user_id>/groups`  
Semantics: remove only the submitted roles.

Example:

```http
DELETE /api/users/<user_id>/groups
Content-Type: application/json
```

```json
{
  "groups": ["it-dep"]
}
```

Response:

```http
HTTP/1.1 200 OK
Content-Type: application/json
```

```json
{
  "added": [],
  "removed": ["it-dep"],
  "groups": ["hr-dep"]
}
```

## Payload notes

Expected payload shape:

```json
{
  "groups": ["role-id-or-role-name"]
}
```

- `groups` must be a list of strings.
- Role identifiers are normalized and de-duplicated while preserving request order.
- Roles can be submitted by ID or name.
- Unknown roles are denied to avoid role enumeration.

## Permissions

- Reading role assignment state uses `read_user_groups`.
- Users may read their own assigned groups.
- Reading another user's role assignment state requires the administration/group-management permission.
- Mutating role assignments uses `manage_groups`.
- Mutating role assignments is administration-only.
- Self role mutation is forbidden.
- Non-superadmins cannot assign or remove superadmin role memberships.
- Superadmin roles are hidden from assignable role options for non-superadmins.

## Logging

Successful role membership update requests are logged with:

- actor user ID;
- target user ID;
- added role IDs;
- removed role IDs.

Example log message:

```text
User '3' updated user '2' groups (added: ['it-dep'], removed: ['hr-dep'])
```

## Search and indexing

- User role names are indexed in the user document as `roles`.
- Administration user search can filter/facet by roles.
- User records are reindexed when role memberships change.
- Users linked to modified/deleted role records are marked for reindexing.




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
