### PR TITLE
feat(moderation): allow passing `data` and `actor_id` to block action

### DIFF
--- a/invenio_users_resources/resources/users/resource.py
+++ b/invenio_users_resources/resources/users/resource.py
@@ -135,11 +135,16 @@ class UsersResource(RecordResource):
         return "", 200
 
     @request_view_args
+    @request_data
     def block(self):
         """Block user."""
+        # The request body is forwarded to the moderation callbacks as-is;
+        # downstream callbacks (e.g. tombstoning in invenio-rdm-records)
+        # decide how to interpret fields such as a removal reason.
         self.service.block(
             id_=resource_requestctx.view_args["id"],
             identity=g.identity,
+            data=resource_requestctx.data or {},
         )
         return "", 200
 

--- a/invenio_users_resources/services/users/service.py
+++ b/invenio_users_resources/services/users/service.py
@@ -173,8 +173,26 @@ class UsersService(RecordService):
         )
 
     @unit_of_work()
-    def block(self, identity, id_, uow=None):
-        """Blocks a user."""
+    def block(self, identity, id_, uow=None, data=None):
+        """Block a user and schedule the registered moderation callbacks.
+
+        The user is marked as blocked synchronously; the follow-up actions
+        registered under the ``block`` moderation action (e.g. tombstoning
+        the user's records and communities) are executed asynchronously via
+        :func:`execute_moderation_actions`.
+
+        :param identity: Identity of the user performing the block; its id
+            is forwarded to the callbacks as ``actor_id`` so they can
+            attribute the action (e.g. on a tombstone's ``removed_by``).
+        :param id_: Id of the user to block.
+        :param uow: The unit of work to register the record operations.
+            Defaults to None.
+        :param data: Free-form dict of caller-supplied context (typically
+            the body of the REST request) forwarded verbatim to every
+            moderation callback. The semantics of individual fields (for
+            example ``removal_reason_id``, ``note``) are defined by the
+            callbacks themselves, not by this service. Defaults to None.
+        """
         user = UserAggregate.get_record(id_)
         if user is None:
             # return 403 even on empty resource due to security implications
@@ -191,7 +209,13 @@ class UsersService(RecordService):
 
         # Register a task to execute callback actions asynchronously, after committing the user
         uow.register(
-            TaskOp(execute_moderation_actions, user_id=user.id, action="block")
+            TaskOp(
+                execute_moderation_actions,
+                user_id=user.id,
+                action="block",
+                actor_id=identity.id,
+                data=data or {},
+            )
         )
         return True
 

--- a/invenio_users_resources/services/users/tasks.py
+++ b/invenio_users_resources/services/users/tasks.py
@@ -69,16 +69,30 @@ def unindex_users(user_ids):
 
 
 @shared_task(ignore_result=True, acks_late=True, retry=True)
-def execute_moderation_actions(user_id=None, action=None):
-    """Execute moderation actions.
+def execute_moderation_actions(user_id=None, action=None, actor_id=None, data=None):
+    """Execute the callbacks registered for a moderation action.
 
-    Callbacks share the same UOW to guarantee data consistency.
-    If any callback fails, then the error is logged and the UOW rolledback.
+    All callbacks registered for ``action`` under the
+    ``invenio_users_resources.moderation.actions`` entry-point group are
+    invoked with a shared unit of work. If any callback raises, the error
+    is logged and the unit of work is rolled back.
 
     Why ``acks_late``:
      - in case the worker fails unexpectedly.
     Why ``retry``:
         - if a task fails, it can be retried afterwards.
+
+    :param user_id: Id of the user that is the subject of the moderation
+        action (e.g. the user being blocked).
+    :param action: Name of the moderation action whose callbacks should be
+        executed (e.g. ``"block"``, ``"restore"``, ``"approve"``).
+    :param actor_id: User id of the actor that triggered the action. It is
+        forwarded to every callback as the ``actor_id`` keyword argument so
+        callbacks can attribute the action (e.g. on a tombstone's
+        ``removed_by``). Defaults to None.
+    :param data: Free-form dict of caller-supplied context. Expanded
+        (``**data``) into every callback's keyword arguments, so its keys
+        are interpreted by the callbacks themselves. Defaults to None.
     """
     actions = current_actions_registry.get(action, [])
 
@@ -88,8 +102,18 @@ def execute_moderation_actions(user_id=None, action=None):
         # Create a uow that is shared by all the callables
         uow = UnitOfWork()
         try:
+            data = data or {}
+            for key in ("uow", "actor_id"):
+                if key in data:
+                    current_app.logger.warning(
+                        "'%s' key is reserved and cannot be used in the data argument of '%s'.",
+                        key,
+                        action,
+                    )
+                    data.pop(key, None)
+
             for callback in actions:
-                callback(user_id, uow=uow)
+                callback(user_id, uow=uow, actor_id=actor_id, **data)
             # Commit the uow when all the callbacks succeeded
             uow.commit()
         except Exception as e:

--- a/tests/services/users/test_user_moderation.py
+++ b/tests/services/users/test_user_moderation.py
@@ -53,11 +53,11 @@ def test_moderation_callbacks_failure(
     - Even if a callback fails, the user block is committed.
     """
 
-    def _block_action_success(user_id, uow=None):
+    def _block_action_success(user_id, uow=None, **kwargs):
         """Action to execute after blocking a user."""
         user_service.approve(system_identity, user_id, uow=uow)
 
-    def _block_action_failure(user_id, uow=None):
+    def _block_action_failure(user_id, uow=None, **kwargs):
         """Action raises an exception."""
         raise Exception("Callback failed")
 
@@ -139,7 +139,7 @@ def test_moderation_callbacks_lock_renewal(
         4) if the lock exists, then it was renewed for 10 seconds.
     """
 
-    def _block_action_success(user_id, uow=None):
+    def _block_action_success(user_id, uow=None, **kwargs):
         """Action to execute after blocking a user."""
         time.sleep(default_timeout)
 


### PR DESCRIPTION
* Allows passing a `data` free-form dict to the block action. This gets
  propagated down to the block action callbacks as expanded kwargs.
* Also passes the user ID from the identity performing the block service
  call as `actor_id`.
