### PR TITLE
fix(groups): keep group name - ids aligned

### DIFF
--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -144,7 +144,7 @@ def _validate_user_data(user_data):
         raise ValidationError(errors)
 
 
-def _validate_group_data(data, exclude_id=None):
+def _validate_group_data(data):
     """Validate the group data."""
     name = data.get("name")
     if not name:
@@ -154,9 +154,6 @@ def _validate_group_data(data, exclude_id=None):
     stmt = select(current_datastore.role_model.id).where(
         current_datastore.role_model.name == name
     )
-    if exclude_id is not None:
-        stmt = stmt.where(current_datastore.role_model.id != exclude_id)
-
     existing_role_id = db.session.execute(stmt).scalar_one_or_none()
 
     if existing_role_id:
@@ -456,8 +453,8 @@ class GroupAggregate(BaseAggregate):
     model_cls = GroupAggregateModel
     """The model class for the user group aggregate."""
 
-    # NOTE: the "uuid" isn't a UUID but contains the same value as the "id"
-    #       field, which is currently a str for Role objects (role.name)!
+    # NOTE: Role identifiers intentionally mirror role names. Permission checks
+    #       use the id field, while configuration stays human-readable.
     dumper = SearchDumper(extensions=[], model_fields={"id": ("uuid", str)})
     """Search index dumper."""
 
@@ -551,12 +548,11 @@ class GroupAggregate(BaseAggregate):
     @classmethod
     def create(cls, data):
         """Create a new group/role and store it in the database."""
-        # Filter out fields sqlalchemy model rejects
-        accepted_fields = [
-            "name",
-            "description",
-        ]
-        role_data = {k: v for k, v in data.items() if k in accepted_fields}
+        role_data = {
+            "id": data["name"],
+            "name": data["name"],
+            "description": data.get("description"),
+        }
 
         _validate_group_data(role_data)
         role = current_datastore.create_role(**role_data)
@@ -571,10 +567,7 @@ class GroupAggregate(BaseAggregate):
         if role is None:
             role = db.session.get(current_datastore.role_model, id_)
 
-        if "name" in data:
-            _validate_group_data({"name": data["name"]}, exclude_id=role.id)
-
-        role.name = data.get("name", role.name)
+        data.pop("name", None)
         role.description = data.get("description", role.description)
         role = current_datastore.update_role(role)
         return self.from_model(role)

--- a/invenio_users_resources/services/generators.py
+++ b/invenio_users_resources/services/generators.py
@@ -3,7 +3,7 @@
 # Copyright (C) 2022 TU Wien.
 # Copyright (C) 2022 CERN.
 # Copyright (C) 2023 Graz University of Technology.
-# Copyright (C) 2024-2025 KTH Royal Institute of Technology.
+# Copyright (C) 2024-2026 KTH Royal Institute of Technology.
 # Copyright (C) 2025 Ubiquity Press.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
@@ -199,10 +199,7 @@ class ProtectedGroupIdentifiers(Generator):
         # update protected role (object form)
         name_obj = getattr(record, "name", None)
         id_obj = getattr(record, "id", None)
-        # update role to protected
-        update_name = kwargs.get("update_grp", {}).get("name")
-
-        candidates = {str(v) for v in (name_dict, name_obj, id_obj, update_name) if v}
+        candidates = {str(v) for v in (name_dict, name_obj, id_obj) if v}
         return bool(protected & candidates)
 
     def excludes(self, record=None, identity=None, **kwargs):

--- a/tests/resources/test_resources_groups.py
+++ b/tests/resources/test_resources_groups.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
-# Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2025-2026 KTH Royal Institute of Technology.
 # Copyright (C) 2025 Northwestern University.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
@@ -23,6 +23,7 @@ def test_group_create_api(app, client, user_moderator):
     res = client.post("/groups", json=payload)
     assert 201 == res.status_code
     data = res.get_json()
+    assert payload["name"] == data["id"]
     assert payload["name"] == data["name"]
     assert payload["description"] == data["description"]
 

--- a/tests/services/test_service_groups.py
+++ b/tests/services/test_service_groups.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 #
 # Copyright (C) 2022 CERN.
-# Copyright (C) 2025 KTH Royal Institute of Technology.
+# Copyright (C) 2025-2026 KTH Royal Institute of Technology.
 #
 # Invenio-Users-Resources is free software; you can redistribute it and/or
 # modify it under the terms of the MIT License; see LICENSE file for more
@@ -10,7 +10,6 @@
 """User service tests."""
 
 from operator import attrgetter
-from uuid import UUID
 
 import pytest
 from invenio_access import ActionRoles, superuser_access
@@ -18,14 +17,6 @@ from invenio_access.permissions import system_identity
 from invenio_records_resources.resources.errors import PermissionDeniedError
 
 from invenio_users_resources.resources.groups.errors import GroupValidationError
-
-
-def is_uuid(value):
-    try:
-        UUID(value)
-        return True
-    except ValueError:
-        return False
 
 
 def test_groups_sort(app, groups, group_service):
@@ -142,7 +133,7 @@ def test_groups_crud(app, group_service, user_pub):
     }
 
     item = group_service.create(system_identity, payload).to_dict()
-    assert is_uuid(item["id"])
+    assert payload["name"] == item["id"]
     assert payload["name"] == item["name"]
     assert payload["description"] == item["description"]
 
@@ -160,8 +151,9 @@ def test_groups_crud(app, group_service, user_pub):
         system_identity,
         item["id"],
         {"name": "another"},
-    )
-    assert "another" == updated["name"]
+    ).to_dict()
+    assert payload["name"] == updated["id"]
+    assert payload["name"] == updated["name"]
 
     with pytest.raises(PermissionDeniedError):
         group_service.update(
@@ -227,7 +219,7 @@ def test_groups_manage_permission_required(
         user_moderator.identity,
         {"name": "perm-check-role-admin", "description": "managed"},
     ).to_dict()
-    assert is_uuid(created["id"])
+    assert "perm-check-role-admin" == created["id"]
 
     updated = group_service.update(
         user_moderator.identity,
@@ -301,39 +293,23 @@ def test_protected_group_not_creatable_via_api(
         app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = previous
 
 
-def test_protected_group_cannot_become_protected(
-    app, group_service, user_moderator, user_admin
-):
-    """Renaming a group into a protected identifier is blocked for admins."""
-
-    previous = app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"]
-    app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = ["protected-admin-role"]
+def test_group_name_cannot_be_changed(app, group_service, user_moderator):
+    """Role names are ignored on update because id/name must stay coupled."""
 
     created = group_service.create(
         user_moderator.identity,
-        {"name": "temp-protected-rename", "description": "temp"},
+        {"name": "temp-immutable-role", "description": "temp"},
     ).to_dict()
 
     try:
-        with pytest.raises(PermissionDeniedError):
-            group_service.update(
-                user_moderator.identity,
-                created["id"],
-                {"name": "protected-admin-role"},
-            )
-        with pytest.raises(PermissionDeniedError):
-            group_service.update(
-                user_admin.identity,
-                created["id"],
-                {"name": "protected-admin-role"},
-            )
-
-        result = group_service.update(
-            system_identity, created["id"], {"name": "protected-admin-role"}
+        updated = group_service.update(
+            system_identity,
+            created["id"],
+            {"name": "renamed-role"},
         ).to_dict()
-        assert result["name"] == "protected-admin-role"
+        assert created["id"] == updated["id"]
+        assert created["name"] == updated["name"]
     finally:
-        app.config["USERS_RESOURCES_PROTECTED_GROUP_NAMES"] = previous
         group_service.delete(system_identity, created["id"])
 
 


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Store new groups with ids matching their names so role identifiers remain human-readable.
* Ignore name changes on group update to keep ids and names coupled after creation.
* Update protected-group checks and tests for immutable group names and name-based ids.
* Depends on: https://github.com/inveniosoftware/invenio-app-rdm/pull/3459

> Note: This PR includes AI-assisted contributions and has been reviewed and refined manually.

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
