### PR TITLE
fix: allow username to be omitted

### DIFF
--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -125,16 +125,17 @@ def _validate_user_data(user_data):
     `commit` state of the UOW and the feedback to the form can't be sent.
     """
     errors = {}
-    username = user_data["username"]
+    username = user_data.get("username")
     email = user_data["email"]
     # Check if Email exists already
     existing_email = db.session.query(User).filter_by(email=email).first()
     if existing_email:
         errors["email"] = [_("Email already used by another account.")]
     # Check if Username exists already
-    existing_username = db.session.query(User).filter_by(username=username).first()
-    if existing_username:
-        errors["username"] = [_("Username already used by another account.")]
+    if username is not None:
+        existing_username = db.session.query(User).filter_by(username=username).first()
+        if existing_username:
+            errors["username"] = [_("Username already used by another account.")]
     if errors:
         raise ValidationError(errors)
 


### PR DESCRIPTION
### Description

* Commit cff2f68 added username validation, effectively making username required (but None could be passed)
* In other parts of Invenio, username is treated as optional.
* This commit restores that behavior by making username optional in this validation check.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
