### PR TITLE
feat(user groups): include management state in api response

### DIFF
--- a/invenio_users_resources/services/users/service.py
+++ b/invenio_users_resources/services/users/service.py
@@ -222,7 +222,9 @@ class UsersService(RecordService):
             identity, "read_user_groups", record=user, actor_id=actor_id
         )
 
-        groups = GroupSchema(many=True, only=("id", "name")).dump(user.get_groups())
+        groups = GroupSchema(many=True, only=("id", "name", "is_managed")).dump(
+            user.get_groups()
+        )
         can_manage_groups = self.check_permission(
             identity, "manage_groups", record=user, actor_id=actor_id
         )

--- a/tests/services/users/test_service_users.py
+++ b/tests/services/users/test_service_users.py
@@ -466,6 +466,27 @@ def test_add_group_normalizes_role_id(user_service, user_moderator, user_pub, gr
     assert "it-dep" in [group["id"] for group in groups]
 
 
+def test_get_groups_includes_management_state(
+    user_service, user_moderator, user_pub, group, not_managed_group
+):
+    """Assigned roles include whether they are managed."""
+    try:
+        user_service.set_groups(
+            user_moderator.identity,
+            user_pub.id,
+            ["it-dep", "not-managed-dep"],
+        )
+
+        groups = user_service.get_groups(user_moderator.identity, user_pub.id)["groups"]
+
+        assert {group["id"]: group["is_managed"] for group in groups} == {
+            "it-dep": True,
+            "not-managed-dep": False,
+        }
+    finally:
+        user_service.set_groups(user_moderator.identity, user_pub.id, [])
+
+
 def test_add_group_empty_role_id_validation(user_service, user_moderator, user_pub):
     """Empty/blank role IDs fail with validation error."""
     with pytest.raises(ValidationError):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

From a UX prespective its more convenient to include whether the role is managed or not.
* Include the `is_managed` field to the user groups response.
* Introduced a test to verify management state inclusion.




### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
