### PR TITLE
fix(user groups): API response for user group changes added field

### DIFF
--- a/invenio_users_resources/records/api.py
+++ b/invenio_users_resources/records/api.py
@@ -390,11 +390,14 @@ class UserAggregate(BaseAggregate):
     def add_groups(self, group_ids):
         """Add multiple group memberships to user if not already assigned."""
         user = self.model.model_obj
+        current_group_ids = set(self.group_ids())
 
         added = []
         for group_role in self._resolve_groups_to_roles(group_ids):
-            if current_datastore.add_role_to_user(user, group_role):
-                added.append(str(group_role.id))
+            group_role_id = str(group_role.id)
+            if group_role_id not in current_group_ids:
+                added.append(group_role_id)
+                current_datastore.add_role_to_user(user, group_role)
 
         return {
             "added": sorted(added),
@@ -405,11 +408,14 @@ class UserAggregate(BaseAggregate):
     def remove_groups(self, group_ids):
         """Remove multiple group memberships from user if assigned."""
         user = self.model.model_obj
+        current_group_ids = set(self.group_ids())
 
         removed = []
         for group_role in self._resolve_groups_to_roles(group_ids):
-            if current_datastore.remove_role_from_user(user, group_role):
-                removed.append(str(group_role.id))
+            group_role_id = str(group_role.id)
+            if group_role_id in current_group_ids:
+                removed.append(group_role_id)
+                current_datastore.remove_role_from_user(user, group_role)
 
         return {
             "added": [],
@@ -419,15 +425,19 @@ class UserAggregate(BaseAggregate):
 
     def set_groups(self, group_ids):
         """Replace group memberships for a user."""
-        requested_groups = self._resolve_groups_to_roles(group_ids)
-        requested_group_ids = {str(group.id) for group in requested_groups}
-        current_group_ids = set(self.group_ids())
+        user = self.model.model_obj
+        requested_groups = {
+            str(group.id): group for group in self._resolve_groups_to_roles(group_ids)
+        }
+        current_groups = {str(group.id): group for group in self.get_groups()}
 
-        to_add = requested_group_ids - current_group_ids
-        to_remove = current_group_ids - requested_group_ids
+        to_add = requested_groups.keys() - current_groups.keys()
+        to_remove = current_groups.keys() - requested_groups.keys()
 
-        self.add_groups(to_add)
-        self.remove_groups(to_remove)
+        for group_id in to_add:
+            current_datastore.add_role_to_user(user, requested_groups[group_id])
+        for group_id in to_remove:
+            current_datastore.remove_role_from_user(user, current_groups[group_id])
 
         return {
             "added": sorted(to_add),

--- a/tests/services/users/test_service_users.py
+++ b/tests/services/users/test_service_users.py
@@ -7,6 +7,7 @@
 
 import pytest
 from invenio_access.permissions import system_identity
+from invenio_accounts.proxies import current_datastore
 from invenio_records_resources.services.errors import PermissionDeniedError
 from marshmallow import ValidationError
 
@@ -464,6 +465,44 @@ def test_add_group_normalizes_role_id(user_service, user_moderator, user_pub, gr
     assert user_service.add_group(user_moderator.identity, user_pub.id, "  it-dep  ")
     groups = user_service.get_groups(user_moderator.identity, user_pub.id)["groups"]
     assert "it-dep" in [group["id"] for group in groups]
+
+
+def test_group_change_reporting_does_not_depend_on_datastore_return(
+    monkeypatch, user_service, user_moderator, user_pub, group
+):
+    """Added/removed are based on actual membership diff, not datastore return."""
+    user_service.set_groups(user_moderator.identity, user_pub.id, [])
+
+    datastore = current_datastore._get_current_object()
+    add_role_to_user = datastore.add_role_to_user
+    remove_role_from_user = datastore.remove_role_from_user
+
+    def add_role_to_user_without_return(user, role):
+        add_role_to_user(user, role)
+        return None
+
+    def remove_role_from_user_without_return(user, role):
+        remove_role_from_user(user, role)
+        return None
+
+    try:
+        monkeypatch.setattr(
+            datastore, "add_role_to_user", add_role_to_user_without_return
+        )
+        result = user_service.add_groups(
+            user_moderator.identity, user_pub.id, ["it-dep"]
+        )
+        assert result["added"] == ["it-dep"]
+
+        monkeypatch.setattr(
+            datastore, "remove_role_from_user", remove_role_from_user_without_return
+        )
+        result = user_service.remove_groups(
+            user_moderator.identity, user_pub.id, ["it-dep"]
+        )
+        assert result["removed"] == ["it-dep"]
+    finally:
+        user_service.set_groups(user_moderator.identity, user_pub.id, [])
 
 
 def test_add_group_empty_role_id_validation(user_service, user_moderator, user_pub):


### PR DESCRIPTION
:heart: Thank you for your contribution!

### Description

* Compute added and removed user groups from current memberships instead of datastore return values.
* Avoid duplicate group mutations during replacement requests.
* Add regression coverage for datastore methods that update memberships without returning a status.


### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [ ] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/community/code-of-conduct/).
- [ ] I've created [logical separate commits](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/community/translations/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/community/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [ ] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/community/code/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/community/code/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/community/code/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/community/code/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/community/code/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
