### PR TITLE
fix(users): rank exact username matches first in user search

### DIFF
--- a/invenio_users_resources/services/users/config.py
+++ b/invenio_users_resources/services/users/config.py
@@ -94,6 +94,45 @@ class UserSearchOptions(SearchOptions, SearchOptionsMixin):
             "profile.full_name^10",
             "profile.affiliations",
         ],
+        clauses=[
+            # Exact username/email match always wins.
+            {
+                "type": "best_fields",
+                "boost": 20,
+                "fields": ["username.keyword", "email.keyword"],
+            },
+            # Multi-term queries spanning fields (e.g. full name + affiliation).
+            {"type": "cross_fields", "boost": 3},
+            # Rewards matches in multiple fields. No fuzziness here: with the ^10
+            # full name boost and the edge-ngram index, fuzzy matches on other
+            # people's names would outscore an exact username match.
+            {"type": "most_fields", "boost": 1},
+            # Typo tolerance on the edge-ngram text fields. Unboosted best_fields
+            # keeps fuzzy noise below exact matches; prefix_length drops
+            # first-character expansions, by far the noisiest.
+            {
+                "type": "best_fields",
+                "boost": 1,
+                "fuzziness": "AUTO",
+                "prefix_length": 1,
+                "fields": [
+                    "username",
+                    "email",
+                    "profile.full_name",
+                    "profile.affiliations",
+                ],
+            },
+            # Typo tolerance on whole usernames/emails. Keyword terms are few
+            # enough that rare usernames survive the fuzzy expansion cap, which
+            # they don't on the edge-ngram fields.
+            {
+                "type": "best_fields",
+                "boost": 3,
+                "fuzziness": "AUTO",
+                "prefix_length": 1,
+                "fields": ["username.keyword", "email.keyword"],
+            },
+        ],
         # Only public emails because hidden emails are stored in email_hidden field.
         allow_list=["username", "email"],
         mapping={

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -191,6 +191,28 @@ def users_data():
             },
         },
         {
+            # Public user whose only searchable info is their username.
+            "username": "sbarton",
+            "email": "sbarton@inveniosoftware.org",
+            "preferences": {
+                "visibility": "public",
+                "email_visibility": "restricted",
+            },
+        },
+        {
+            # Full name fuzzy-matches "sbarton" ("barton" edge-gram, one edit).
+            "username": "abartonelli",
+            "email": "abartonelli@inveniosoftware.org",
+            "profile": {
+                "full_name": "Anna Bartonelli",
+                "affiliations": "ACME",
+            },
+            "preferences": {
+                "visibility": "public",
+                "email_visibility": "restricted",
+            },
+        },
+        {
             "username": "pub",
             "email": "pub@inveniosoftware.org",
             "profile": {

--- a/tests/services/users/test_service_users.py
+++ b/tests/services/users/test_service_users.py
@@ -45,7 +45,7 @@ def test_search_restricted(user_service, anon_identity, user_pub):
 def test_search_public_users(user_service, user_pub):
     """Only public users are shown in search."""
     res = user_service.search(user_pub.identity).to_dict()
-    assert res["hits"]["total"] == 2  # 2 public users in conftest
+    assert res["hits"]["total"] == 4  # 4 public users in conftest
 
 
 # Admin search
@@ -138,6 +138,19 @@ def test_user_search_field(user_service, user_pub, query, expected_usernames):
     res = user_service.search(user_pub.identity, suggest=query).to_dict()
     usernames = [entry["username"] for entry in res["hits"]["hits"]]
     assert sorted(usernames) == expected_usernames
+
+
+def test_user_search_exact_username_first(user_service, user_pub):
+    """An exact username match outranks fuzzy full-name matches."""
+    res = user_service.search(user_pub.identity, suggest="sbarton").to_dict()
+    assert res["hits"]["hits"][0]["username"] == "sbarton"
+
+
+@pytest.mark.parametrize("query", ["sbraton", "sbartn", "sbartoon"])
+def test_user_search_username_typo(user_service, user_pub, query):
+    """A typo'd username (first character excepted) still finds the user."""
+    res = user_service.search(user_pub.identity, suggest=query).to_dict()
+    assert "sbarton" in [entry["username"] for entry in res["hits"]["hits"]]
 
 
 #


### PR DESCRIPTION
> AI Disclaimer: the different clauses were explored and generated by Claude Code using past unsuccessful search queries reported by users as cases we wanted to fix. I think it's reasonable to expect exact username/email matches to be ranked higher, since before this they were all mashed together with the name/affiliation fields, which made the results very noisy.

* Split the suggest query into exact, cross-field, and fuzzy clauses so
  fuzzy full-name matches no longer outscore exact username matches.
* Add a fuzzy clause on the keyword fields: rare usernames get dropped
  from the fuzzy expansion set on the edge-ngram fields, so typo'd
  usernames were often not found at all.
* Fuzzy matching no longer covers typos in the first character
  (prefix_length), which cuts most of the fuzzy noise.
