### PR TITLE
fix(resources): add type converters to the resource endpoints

### DIFF
--- a/invenio_users_resources/resources/groups/config.py
+++ b/invenio_users_resources/resources/groups/config.py
@@ -55,8 +55,8 @@ class GroupsResourceConfig(RecordResourceConfig):
     url_prefix = "/groups"
     routes = {
         "list": "",
-        "item": "/<id>",
-        "item-avatar": "/<id>/avatar.svg",
+        "item": "/<string:id>",
+        "item-avatar": "/<string:id>/avatar.svg",
     }
 
     request_view_args = {

--- a/invenio_users_resources/resources/users/config.py
+++ b/invenio_users_resources/resources/users/config.py
@@ -49,15 +49,15 @@ class UsersResourceConfig(RecordResourceConfig):
     routes = {
         "list": "",
         "search_all": "/all",
-        "item": "/<id>",
-        "groups-list": "/<id>/groups",
-        "item-avatar": "/<id>/avatar.svg",
-        "approve": "/<id>/approve",
-        "block": "/<id>/block",
-        "restore": "/<id>/restore",
-        "activate": "/<id>/activate",
-        "deactivate": "/<id>/deactivate",
-        "impersonate": "/<id>/impersonate",
+        "item": "/<user_id:id>",
+        "groups-list": "/<user_id:id>/groups",
+        "item-avatar": "/<user_id:id>/avatar.svg",
+        "approve": "/<user_id:id>/approve",
+        "block": "/<user_id:id>/block",
+        "restore": "/<user_id:id>/restore",
+        "activate": "/<user_id:id>/activate",
+        "deactivate": "/<user_id:id>/deactivate",
+        "impersonate": "/<user_id:id>/impersonate",
     }
 
     request_view_args = {

--- a/invenio_users_resources/utils.py
+++ b/invenio_users_resources/utils.py
@@ -1,0 +1,38 @@
+# SPDX-FileCopyrightText: 2026 TU Wien.
+# SPDX-License-Identifier: MIT
+
+"""Utilities for Invenio-Users-Resources."""
+
+from werkzeug.routing import BaseConverter, ValidationError
+
+
+class UserIDConverter(BaseConverter):
+    """Flask URL converter for user IDs."""
+
+    def __init__(self, map, special_value=None):
+        """Constructor."""
+        self.special_value = special_value or "system"
+
+    def to_python(self, value):
+        """Accept the special value (e.g. "system") or any positive integer value."""
+        try:
+            if value == self.special_value:
+                return None
+
+            # make sure that we're dealing with a positive integer
+            value = int(value)
+            if value <= 0:
+                raise ValidationError()
+
+            # the marshmallow validation layer expects a string
+            return str(value)
+        except ValueError as e:
+            raise ValidationError() from e
+
+    def to_url(self, value):
+        """Turn the user ID into a string."""
+        return (
+            self.special_value
+            if value is None or value == self.special_value
+            else str(value)
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ invenio_groups = "invenio_users_resources.views:create_groups_resources_bp"
 invenio_users = "invenio_users_resources.views:create_users_resources_bp"
 invenio_users_resources = "invenio_users_resources.views:blueprint"
 
+[project.entry-points."invenio_base.api_converters"]
+user_id = "invenio_users_resources.utils:UserIDConverter"
+
 [project.entry-points."invenio_base.api_finalize_app"]
 invenio_users_resources = "invenio_users_resources.ext:api_finalize_app"
 
@@ -57,6 +60,9 @@ invenio_users_resources = "invenio_users_resources.ext:InvenioUsersResources"
 
 [project.entry-points."invenio_base.blueprints"]
 invenio_users_resources = "invenio_users_resources.views:blueprint"
+
+[project.entry-points."invenio_base.converters"]
+user_id = "invenio_users_resources.utils:UserIDConverter"
 
 [project.entry-points."invenio_base.finalize_app"]
 invenio_users_resources = "invenio_users_resources.ext:finalize_app"


### PR DESCRIPTION
Previously, the endpoints would accept any string for user IDs and forward them to the service/database.
Since the user IDs are defined to be integers, this would then fail for requests where the ID is not a valid integer literal and return an HTTP 500 response.

This PR makes it so Flask catches invalid user IDs for us.

For the record, even in this package here we already incorporated knowledge about the user ID being an integer: https://github.com/inveniosoftware/invenio-users-resources/blob/v13.0.1/invenio_users_resources/records/api.py#L182